### PR TITLE
[MNT} CI on PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,11 @@ name: Python CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
I noticed that CI does not run - or queue with wait for admin authorization - in this PR https://github.com/felipeangelimvieira/prophetverse/pull/16.

Not sure why, perhaps the syntax in the GHA yml should be like this?