### PR TITLE
Add ProphetGamma and ProphetNegbinomial models

### DIFF
--- a/src/prophetverse/distributions.py
+++ b/src/prophetverse/distributions.py
@@ -1,0 +1,24 @@
+from jax import numpy as jnp
+from numpyro import distributions as dist
+from numpyro.distributions import constraints
+from numpyro.distributions.util import promote_shapes
+
+
+class GammaReparametrized(dist.Gamma):
+    arg_constraints = {
+        "loc": constraints.positive,
+        "scale": constraints.positive,
+    }
+    support = constraints.positive
+    reparametrized_params = ["loc", "scale"]
+
+    def __init__(self, loc, scale=1.0, *, validate_args=None):
+
+        self.loc, self.scale = promote_shapes(loc, scale)
+
+        rate = loc/ (scale ** 2)
+        concentration = loc * rate
+
+        super(GammaReparametrized, self).__init__(
+            rate=rate, concentration=concentration, validate_args=validate_args
+        )

--- a/src/prophetverse/models.py
+++ b/src/prophetverse/models.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 import numpyro
 from numpyro import distributions as dist
 
+from prophetverse.distributions import GammaReparametrized
 from prophetverse.effects import AbstractEffect
 from prophetverse.trend.base import TrendModel
 
@@ -106,7 +107,68 @@ def univariate_model(
         exogenous_effects (dict): Dictionary containing the exogenous effects.
         noise_scale (float): Noise scale.
     """
-        
+
+    mean = _compute_mean_univariate(
+        trend_model=trend_model,
+        trend_data=trend_data,
+        data=data,
+        exogenous_effects=exogenous_effects,
+    )
+
+    noise_scale = numpyro.sample("noise_scale", dist.HalfNormal(noise_scale))
+
+    with numpyro.plate("data", len(mean), dim=-2) as time_plate:
+        numpyro.sample(
+            "obs",
+            dist.Normal(mean.reshape((-1, 1)), noise_scale),
+            obs=y,
+        )
+
+
+def univariate_gamma_model(
+    y,
+    trend_model: TrendModel,
+    trend_data: Dict[str, jnp.ndarray],
+    data: Dict[str, jnp.ndarray] = None,
+    exogenous_effects: Dict[str, AbstractEffect] = None,
+    noise_scale=0.5,
+):
+    """
+    Defines the Prophet-like model for univariate timeseries.
+
+    Args:
+        y (jnp.ndarray): Array of time series data.
+        trend_model (TrendModel): Trend model.
+        trend_data (dict): Dictionary containing the data needed for the trend model.
+        data (dict): Dictionary containing the exogenous data.
+        exogenous_effects (dict): Dictionary containing the exogenous effects.
+        noise_scale (float): Noise scale.
+    """
+
+    mean = _compute_mean_univariate(
+        trend_model=trend_model,
+        trend_data=trend_data,
+        data=data,
+        exogenous_effects=exogenous_effects,
+    )
+    mean = jnp.clip(mean, a_min=1e-6, a_max=None)
+    
+    noise_scale = numpyro.sample("noise_scale", dist.HalfNormal(noise_scale))
+
+    with numpyro.plate("data", len(mean), dim=-2) as time_plate:
+        numpyro.sample(
+            "obs",
+            GammaReparametrized(mean.reshape((-1, 1)), noise_scale),
+            obs=y,
+        )
+
+
+def _compute_mean_univariate(
+    trend_model: TrendModel,
+    trend_data: Dict[str, jnp.ndarray], 
+    data: Dict[str, jnp.ndarray] = None,
+    exogenous_effects: Dict[str, AbstractEffect] = None,
+    ):
     trend = trend_model(**trend_data)
 
     numpyro.deterministic("trend", trend)
@@ -121,13 +183,4 @@ def univariate_model(
             effect = exog_effect(trend=trend, data=exog_data)
             numpyro.deterministic(key, effect)
             mean += effect
-
-    noise_scale = numpyro.sample("noise_scale", dist.HalfNormal(noise_scale))
-
-    with numpyro.plate("data", len(mean), dim=-2) as time_plate:
-        s = numpyro.sample(
-            "obs",
-            dist.Normal(mean.reshape((-1, 1)), noise_scale),
-            obs=y,
-        )
-        s
+    return mean

--- a/src/prophetverse/sktime/__init__.py
+++ b/src/prophetverse/sktime/__init__.py
@@ -1,2 +1,2 @@
 from .multivariate import HierarchicalProphet
-from .univariate import Prophet
+from .univariate import *

--- a/src/prophetverse/sktime/univariate.py
+++ b/src/prophetverse/sktime/univariate.py
@@ -12,13 +12,15 @@ from jax import random
 from numpyro import distributions as dist
 from sktime.forecasting.base import ForecastingHorizon
 
-from prophetverse.models import univariate_gamma_model, univariate_model
+from prophetverse.models import (univariate_gamma_model, univariate_model,
+                                 univariate_negbinomial_model)
 from prophetverse.sktime.base import (BaseBayesianForecaster,
                                       ExogenousEffectMixin)
+from prophetverse.trend.flat import FlatTrend
 from prophetverse.trend.piecewise import (PiecewiseLinearTrend,
                                           PiecewiseLogisticTrend, TrendModel)
 
-__all__ = ["Prophet", "ProphetGamma"]
+__all__ = ["Prophet", "ProphetGamma", "ProphetNegBinomial"]
 
 
 class Prophet(ExogenousEffectMixin, BaseBayesianForecaster):
@@ -139,7 +141,7 @@ class Prophet(ExogenousEffectMixin, BaseBayesianForecaster):
             raise ValueError("capacity_prior_scale must be greater than 0.")
         if self.capacity_prior_loc <= 0:
             raise ValueError("capacity_prior_loc must be greater than 0.")
-        if self.trend not in ["linear", "logistic"]:
+        if self.trend not in ["linear", "logistic", "flat"] and not isinstance(self.trend, TrendModel):
             raise ValueError('trend must be either "linear" or "logistic".')
 
     def _get_fit_data(self, y, X, fh):
@@ -157,33 +159,7 @@ class Prophet(ExogenousEffectMixin, BaseBayesianForecaster):
 
         fh = y.index.get_level_values(-1).unique()
 
-        ## Changepoints and trend
-        if self.trend == "linear":
-            self.trend_model_ = PiecewiseLinearTrend(
-                changepoint_interval=self.changepoint_interval,
-                changepoint_range=self.changepoint_range,
-                changepoint_prior_scale=self.changepoint_prior_scale)
-
-        elif self.trend == "logistic":
-            self.trend_model_ = PiecewiseLogisticTrend(
-                changepoint_interval=self.changepoint_interval,
-                changepoint_range=self.changepoint_range,
-                changepoint_prior_scale=self.changepoint_prior_scale,
-                capacity_prior=dist.TransformedDistribution(
-                    dist.HalfNormal(self.capacity_prior_scale),
-                    dist.transforms.AffineTransform(
-                        loc=self.capacity_prior_loc, scale=1
-                    ),
-                )
-            )
-
-        elif isinstance(self.trend, TrendModel):
-            self.trend_model_ = self.trend
-        else:
-            raise ValueError(
-                "trend must be either 'linear', 'logistic' or a TrendModel instance."
-            )
-
+        self.trend_model_ = self._get_trend_model()
         self.trend_model_.initialize(y)
 
         trend_data = self.trend_model_.prepare_input_data(fh)
@@ -260,8 +236,74 @@ class Prophet(ExogenousEffectMixin, BaseBayesianForecaster):
             **self.fit_and_predict_data_,
         )
 
+    def _get_trend_model(self):
+        """
+        Returns the trend model based on the specified trend parameter.
+
+        Returns:
+            TrendModel: The trend model based on the specified trend parameter.
+
+        Raises:
+            ValueError: If the trend parameter is not one of 'linear', 'logistic', 'flat' or a TrendModel instance.
+        """
+
+        ## Changepoints and trend
+        if self.trend == "linear":
+            return PiecewiseLinearTrend(
+                changepoint_interval=self.changepoint_interval,
+                changepoint_range=self.changepoint_range,
+                changepoint_prior_scale=self.changepoint_prior_scale,
+            )
+
+        elif self.trend == "logistic":
+            return PiecewiseLogisticTrend(
+                changepoint_interval=self.changepoint_interval,
+                changepoint_range=self.changepoint_range,
+                changepoint_prior_scale=self.changepoint_prior_scale,
+                capacity_prior=dist.TransformedDistribution(
+                    dist.HalfNormal(self.capacity_prior_scale),
+                    dist.transforms.AffineTransform(
+                        loc=self.capacity_prior_loc, scale=1
+                    ),
+                ),
+            )
+        elif self.trend == "flat":
+            return FlatTrend(
+                changepoint_prior_scale=self.changepoint_prior_scale
+            )
+
+        elif isinstance(self.trend, TrendModel):
+            return self.trend
+        
+        raise ValueError(
+            "trend must be either 'linear', 'logistic' or a TrendModel instance."
+        )
+
 
 class ProphetGamma(Prophet):
+    """
+    A subclass of Prophet that models time series data with a gamma likelihood. Useful for positive only timeseries.
+
+    Parameters:
+    - changepoint_interval (int): The number of points between potential changepoints. Default is 25.
+    - changepoint_range (float): Proportion of history in which trend changepoints will be estimated. Default is 0.8.
+    - changepoint_prior_scale (float): Parameter modulating the flexibility of the automatic changepoint selection. Default is 0.001.
+    - feature_transformer (object): A transformer object to preprocess exogenous features. Default is None.
+    - capacity_prior_scale (float): Scale parameter for the capacity prior distribution. Default is 0.2.
+    - capacity_prior_loc (float): Location parameter for the capacity prior distribution. Default is 1.1.
+    - noise_scale (float): Scale parameter for the observation noise. Default is 0.05.
+    - trend (str): Type of trend component. Default is "logistic".
+    - mcmc_samples (int): Number of MCMC samples. Default is 2000.
+    - mcmc_warmup (int): Number of MCMC warmup steps. Default is 200.
+    - mcmc_chains (int): Number of MCMC chains. Default is 4.
+    - inference_method (str): Method for inference. Default is "map".
+    - optimizer_name (str): Name of the optimizer. Default is "Adam".
+    - optimizer_kwargs (dict): Additional keyword arguments for the optimizer. Default is None.
+    - optimizer_steps (int): Number of optimizer steps. Default is 1000.
+    - exogenous_effects (list): List of exogenous effects. Default is None.
+    - default_effect (object): Default effect for exogenous features. Default is None.
+    - rng_key (jax.random.PRNGKey): Random number generator key. Default is None.
+    """
 
     def __init__(
         self,
@@ -285,9 +327,6 @@ class ProphetGamma(Prophet):
         rng_key=None,
     ):
         
-        if trend == "linear":
-            raise ValueError("trend must be 'logistic' for the ProphetGamma model, or a custom TrendModel with guaranteed positive values.")
-        
         super().__init__(
             changepoint_interval=changepoint_interval,
             changepoint_range=changepoint_range,
@@ -307,5 +346,150 @@ class ProphetGamma(Prophet):
             exogenous_effects=exogenous_effects,
             default_effect=default_effect,
             rng_key=rng_key)
-        
+
         self.model = univariate_gamma_model
+
+
+class ProphetNegBinomial(Prophet):
+    """
+    A subclass of Prophet that models time series data with a negative binomial likelihood. Useful for count data.
+
+    Parameters:
+    - changepoint_interval (int): The number of points between potential changepoints. Default is 25.
+    - changepoint_range (float): Proportion of history in which trend changepoints will be estimated. Default is 0.8.
+    - changepoint_prior_scale (float): Parameter modulating the flexibility of the automatic changepoint selection. Default is 0.001.
+    - feature_transformer (object): A transformer object to preprocess exogenous features. Default is None.
+    - capacity_prior_scale (float): Scale parameter for the capacity prior distribution. Default is 0.2.
+    - capacity_prior_loc (float): Location parameter for the capacity prior distribution. Default is 1.1.
+    - noise_scale (float): Scale parameter for the observation noise. Default is 0.05.
+    - trend (str): Type of trend component. Default is "logistic".
+    - mcmc_samples (int): Number of MCMC samples. Default is 2000.
+    - mcmc_warmup (int): Number of MCMC warmup steps. Default is 200.
+    - mcmc_chains (int): Number of MCMC chains. Default is 4.
+    - inference_method (str): Method for inference. Default is "map".
+    - optimizer_name (str): Name of the optimizer. Default is "Adam".
+    - optimizer_kwargs (dict): Additional keyword arguments for the optimizer. Default is None.
+    - optimizer_steps (int): Number of optimizer steps. Default is 1000.
+    - exogenous_effects (list): List of exogenous effects. Default is None.
+    - default_effect (object): Default effect for exogenous features. Default is None.
+    - rng_key (jax.random.PRNGKey): Random number generator key. Default is None.
+    """
+
+    def __init__(
+        self,
+        changepoint_interval=25,
+        changepoint_range=0.8,
+        changepoint_prior_scale=0.001,
+        feature_transformer=None,
+        capacity_prior_scale=0.2,
+        capacity_prior_loc=1.1,
+        noise_scale=0.05,
+        trend="logistic",
+        mcmc_samples=2000,
+        mcmc_warmup=200,
+        mcmc_chains=4,
+        inference_method="map",
+        optimizer_name="Adam",
+        optimizer_kwargs=None,
+        optimizer_steps=1_000,
+        exogenous_effects=None,
+        default_effect=None,
+        rng_key=None,
+    ):
+
+        super().__init__(
+            changepoint_interval=changepoint_interval,
+            changepoint_range=changepoint_range,
+            changepoint_prior_scale=changepoint_prior_scale,
+            feature_transformer=feature_transformer,
+            capacity_prior_scale=capacity_prior_scale,
+            capacity_prior_loc=capacity_prior_loc,
+            noise_scale=noise_scale,
+            trend=trend,
+            mcmc_samples=mcmc_samples,
+            mcmc_warmup=mcmc_warmup,
+            mcmc_chains=mcmc_chains,
+            inference_method=inference_method,
+            optimizer_name=optimizer_name,
+            optimizer_kwargs=optimizer_kwargs,
+            optimizer_steps=optimizer_steps,
+            exogenous_effects=exogenous_effects,
+            default_effect=default_effect,
+            rng_key=rng_key,
+        )
+
+        self.model = univariate_negbinomial_model
+
+    def _scale_y(self, y : pd.DataFrame):
+        """
+        We skip the scaling of the data, as the negative binomial need integer values.
+        
+        However, we keep the timeseries scale to scale the changepoint coefficients, and parameters,
+        for the latent mean.
+        """
+        return y
+
+    def _inv_scale_y(self, y):
+        """
+        We skip the scaling of the data, as the negative binomial need integer values.
+
+        However, we keep the timeseries scale to scale the changepoint coefficients, and parameters,
+        for the latent mean.
+        """
+        return y
+
+    def _get_fit_data(self, y, X, fh):
+        """
+        Prepares the data for the Numpyro model.
+
+        Args:
+            y (pd.DataFrame): Time series data.
+            X (pd.DataFrame): Exogenous variables.
+            fh (ForecastingHorizon): Forecasting horizon.
+
+        Returns:
+            dict: Dictionary of data for the Numpyro model.
+        """
+
+        fh = y.index.get_level_values(-1).unique()
+
+        self.trend_model_ = self._get_trend_model()
+        self.trend_model_.initialize(y/self._scale)
+
+        trend_data = self.trend_model_.prepare_input_data(fh)
+
+        ## Exogenous features
+
+        if X is None:
+            X = pd.DataFrame(index=y.index)
+
+        if self.feature_transformer is not None:
+
+            X = self.feature_transformer.fit_transform(X)
+
+        self._has_exogenous = ~X.columns.empty
+        X = X.loc[y.index]
+
+        self._set_custom_effects(X.columns)
+        exogenous_data = self._get_exogenous_data_array(X)
+
+        y_array = jnp.array(y.values.flatten()).reshape((-1, 1))
+
+        ## Inputs that also are used in predict
+        self.fit_and_predict_data_ = {
+            "trend_model": self.trend_model_,
+            "noise_scale": self.noise_scale,
+            "exogenous_effects": (
+                self.exogenous_effect_dict if self._has_exogenous else None
+            ),
+            "scale" : self._scale,
+        }
+
+        inputs = {
+            "y": y_array,
+            "data": exogenous_data,
+            "trend_data": trend_data,
+            **self.fit_and_predict_data_,
+        }
+
+        return inputs

--- a/src/prophetverse/trend/base.py
+++ b/src/prophetverse/trend/base.py
@@ -94,3 +94,7 @@ class TrendModel(ABC):
 
     def __call__(self, **kwargs):
         return self.compute_trend(**kwargs)
+
+        
+        
+        

--- a/src/prophetverse/trend/flat.py
+++ b/src/prophetverse/trend/flat.py
@@ -1,0 +1,46 @@
+from typing import Tuple, Union
+
+import jax.numpy as jnp
+import numpyro
+import numpyro.distributions as dist
+import pandas as pd
+
+from prophetverse.utils.frame_to_array import series_to_tensor
+
+from .base import TrendModel
+
+
+class FlatTrend(TrendModel):
+    
+
+    def __init__(self, changepoint_prior_scale=0.1) -> None:
+        self.changepoint_prior_scale = changepoint_prior_scale
+        super().__init__()
+
+    def initialize(self, y: pd.DataFrame):
+
+        self.changepoint_prior_loc = y.mean().values
+
+    def prepare_input_data(self, idx: pd.PeriodIndex) -> dict:
+
+        return {
+            "constant_vector": jnp.ones((len(idx), 1)),
+        }
+        
+    def compute_trend(self, constant_vector):
+        
+        mean =self.changepoint_prior_loc
+        var = self.changepoint_prior_scale**2
+        
+        rate = mean / var
+        concentration = mean * rate 
+        
+        coefficient = numpyro.sample(
+            "trend_flat_coefficient",
+            dist.Gamma(
+                rate=rate,
+                concentration=concentration,
+            )
+        )
+        
+        return constant_vector * coefficient

--- a/tests/distributions/test_gamma.py
+++ b/tests/distributions/test_gamma.py
@@ -1,0 +1,56 @@
+import pytest
+from jax import random
+from numpyro import distributions as dist
+
+from prophetverse.distributions import GammaReparametrized
+
+
+@pytest.mark.parametrize(
+    "loc, scale",
+    [
+        (1.0, 1.0),
+        (10.0, 1.0),
+        (5.0, 2.0),
+    ],
+)
+def test_gamma_reparametrized_init(loc, scale):
+    dist_test = GammaReparametrized(loc, scale)
+    assert dist_test.loc == loc
+    assert dist_test.scale == scale
+    assert isinstance(dist_test, GammaReparametrized)
+
+
+@pytest.mark.parametrize(
+    "loc, scale",
+    [
+        (1.0, 1.0),
+        (10.0, 1.0),
+        (5.0, 2.0),
+    ],
+)
+def test_gamma_reparametrized_moments(loc, scale):
+    dist_test = GammaReparametrized(loc, scale)
+    mean_expected = loc
+    var_expected = scale**2
+    assert dist_test.mean == pytest.approx(mean_expected)
+    assert dist_test.variance == pytest.approx(var_expected)
+
+
+def test_gamma_reparametrized_sample_shape():
+    key = random.PRNGKey(0)
+    dist_test = GammaReparametrized(10.0, 1.0)
+    samples = dist_test.sample(key, (100,))
+    assert samples.shape == (100,)
+
+
+@pytest.mark.parametrize("value", [0.5, 1.5, 3.5])
+def test_gamma_reparametrized_log_prob(value):
+    loc = 10.0
+    scale = 2.0
+    dist_test = GammaReparametrized(loc, scale)
+    rate = loc / (scale**2)
+    concentration = loc * rate
+    dist_standard = dist.Gamma(rate=rate, concentration=concentration)
+    log_prob_reparam = dist_test.log_prob(value)
+    log_prob_standard = dist_standard.log_prob(value)
+    assert log_prob_reparam == pytest.approx(log_prob_standard)

--- a/tests/sktime/test_sktime_contract.py
+++ b/tests/sktime/test_sktime_contract.py
@@ -13,9 +13,10 @@ from skbase.utils.deep_equals._deep_equals import (_coerce_list, _dict_equals,
                                                    _tuple_equals)
 from sktime.utils.estimator_checks import check_estimator
 
-from prophetverse.sktime import HierarchicalProphet, Prophet
+from prophetverse.sktime import (HierarchicalProphet, Prophet, ProphetGamma,
+                                 ProphetNegBinomial)
 
-PROPHET_MODELS = [Prophet, HierarchicalProphet]
+PROPHET_MODELS = [Prophet, ProphetGamma, ProphetNegBinomial, HierarchicalProphet]
 
 @pytest.mark.skip(reason="Waiting for skbase update")
 @pytest.mark.parametrize("model", PROPHET_MODELS)

--- a/tests/trend/test_flat.py
+++ b/tests/trend/test_flat.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+
+import jax.numpy as jnp
+import numpyro
+import pandas as pd
+import pytest
+from numpy.testing import assert_almost_equal
+
+from prophetverse.trend.flat import \
+    FlatTrend  # Assuming this is the import path
+
+
+@pytest.fixture
+def trend_model():
+    return FlatTrend(changepoint_prior_scale=0.1)
+
+
+@pytest.fixture
+def timeseries_data():
+    date_rng = pd.date_range(start="1/1/2022", end="1/10/2022", freq="D")
+    df = pd.DataFrame(date_rng, columns=["date"])
+    df["data"] = jnp.arange(len(date_rng))
+    df = df.set_index("date")
+    return df
+
+
+def test_initialization(trend_model):
+    assert trend_model.changepoint_prior_scale == 0.1
+
+
+def test_initialize(trend_model, timeseries_data):
+    trend_model.initialize(timeseries_data)
+    expected_loc = timeseries_data["data"].mean()
+    assert_almost_equal(trend_model.changepoint_prior_loc, expected_loc)
+
+
+def test_prepare_input_data(trend_model, timeseries_data):
+    idx = timeseries_data.index.to_period("D")
+    result = trend_model.prepare_input_data(idx)
+    assert "constant_vector" in result
+    assert result["constant_vector"].shape == (len(idx), 1)
+    assert jnp.all(result["constant_vector"] == 1)
+
+
+def test_compute_trend(trend_model, timeseries_data):
+    idx = timeseries_data.index.to_period("D")
+    trend_model.initialize(timeseries_data)
+    data = trend_model.prepare_input_data(idx)
+    constant_vector = data["constant_vector"]
+
+    with numpyro.handlers.seed(rng_seed=0):
+        trend_result = trend_model.compute_trend(constant_vector)
+
+    assert jnp.unique(trend_result).shape == (1,)
+    assert trend_result.shape == (len(idx), 1)


### PR DESCRIPTION
This PR adds Prophet-like models with Gamma and negative binomial as likelihoods. A "soft clip" function was used to avoid passing negative values to Gamma and Neg. Bin. distributions, which seemed good according to some tests I made on toy datasets. I'll soon post some examples in the documentation.
