### PR TITLE
[MNT] Fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,10 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
+        args:
+          - --ignore=E121,E123,E126,E226,E24,E704,W503,W504
+          - --max-line-length=88
+          - --extend-ignore=E203
         additional_dependencies: [flake8-bugbear, flake8-print]
 
   - repo: https://github.com/mgedmin/check-manifest
@@ -96,7 +100,8 @@ repos:
     hooks:
       - id: pydocstyle
         args:
-          - --config=setup.cfg
+          - --convention=numpy
+          - --match=(?!test_).*\.py
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.9.0.6


### PR DESCRIPTION
The pattern of sktime pre-commit was referencing a setup.cfg file that does not exist in prophetverse. 
So the configurations were passed explicit at the pre-commit-config.yaml.