### PR TITLE
[FIX] Suggested capacity value when y is not scaled

### DIFF
--- a/src/prophetverse/trend/piecewise.py
+++ b/src/prophetverse/trend/piecewise.py
@@ -470,7 +470,7 @@ class PiecewiseLogisticTrend(PiecewiseLinearTrend):
         if hasattr(self.capacity_prior, "loc"):
             capacity_prior_loc = self.capacity_prior.loc
         else:
-            capacity_prior_loc = 1.05
+            capacity_prior_loc = y_arrays.max() * 1.05
 
         global_rates, offset = _suggest_logistic_rate_and_offset(
             t=t_arrays.squeeze(),


### PR DESCRIPTION
The suggested capacity 1.05 for computing smart global rate and offset does not work for ProphetNegBinomial since scaling is not applied and not all values are smaller than 1.05.
