### PR TITLE
[FIX] Fix type hints | operator which is not compatible with Python 3.9

### DIFF
--- a/src/prophetverse/effects/base.py
+++ b/src/prophetverse/effects/base.py
@@ -1,7 +1,7 @@
 """Module that stores abstract class of effects."""
 
 from abc import ABC, abstractmethod
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import jax.numpy as jnp
 import numpyro
@@ -22,7 +22,7 @@ class AbstractEffect(ABC):
         self.id = id
         self.regex = regex
 
-    def match_columns(self, columns: pd.Index | List[str]) -> pd.Index:
+    def match_columns(self, columns: Union[pd.Index, List[str]]) -> pd.Index:
         """Match the columns of the DataFrame with the regex pattern.
 
         Parameters

--- a/src/prophetverse/effects/effect_apply.py
+++ b/src/prophetverse/effects/effect_apply.py
@@ -8,7 +8,7 @@ from prophetverse.utils.algebric_operations import matrix_multiplication
 
 __all__ = ["additive_effect", "multiplicative_effect"]
 
-effects_application = Literal["additive", "multiplicative"]
+EFFECT_APPLICATION_TYPE = Literal["additive", "multiplicative"]
 
 
 def additive_effect(data: jnp.ndarray, coefficients: jnp.ndarray) -> jnp.ndarray:

--- a/src/prophetverse/effects/hill.py
+++ b/src/prophetverse/effects/hill.py
@@ -1,11 +1,13 @@
 """Definition of Hill Effect class."""
 
+from typing import Optional
+
 import jax.numpy as jnp
 from numpyro import distributions as dist
 from numpyro.distributions import Distribution
 
 from prophetverse.effects.base import AbstractEffect
-from prophetverse.effects.effect_apply import effects_application
+from prophetverse.effects.effect_apply import EFFECT_APPLICATION_TYPE
 from prophetverse.utils.algebric_operations import _exponent_safe
 
 __all__ = ["HillEffect"]
@@ -16,11 +18,11 @@ class HillEffect(AbstractEffect):
 
     Parameters
     ----------
-    half_max_prior : None | Distribution, optional
+    half_max_prior : Distribution, optional
         Prior distribution for the half-maximum parameter
-    slope_prior : None | Distribution, optional
+    slope_prior : Distribution, optional
         Prior distribution for the slope parameter
-    max_effect_prior : None | Distribution, optional
+    max_effect_prior : Distribution, optional
         Prior distribution for the maximum effect parameter
     effect_mode : effects_application, optional
         Mode of the effect (either "additive" or "multiplicative")
@@ -28,10 +30,10 @@ class HillEffect(AbstractEffect):
 
     def __init__(
         self,
-        half_max_prior: None | Distribution = None,
-        slope_prior: None | Distribution = None,
-        max_effect_prior: None | Distribution = None,
-        effect_mode: effects_application = "multiplicative",
+        half_max_prior: Optional[Distribution] = None,
+        slope_prior: Optional[Distribution] = None,
+        max_effect_prior: Optional[Distribution] = None,
+        effect_mode: EFFECT_APPLICATION_TYPE = "multiplicative",
         **kwargs,
     ):
         self.half_max_prior = half_max_prior or dist.Gamma(1, 1)

--- a/src/prophetverse/effects/linear.py
+++ b/src/prophetverse/effects/linear.py
@@ -1,5 +1,7 @@
 """Definition of Linear Effect class."""
 
+from typing import Optional
+
 import jax.numpy as jnp
 import numpyro
 from numpyro import distributions as dist
@@ -7,8 +9,8 @@ from numpyro.distributions import Distribution
 
 from prophetverse.effects.base import AbstractEffect
 from prophetverse.effects.effect_apply import (
+    EFFECT_APPLICATION_TYPE,
     additive_effect,
-    effects_application,
     multiplicative_effect,
 )
 
@@ -20,7 +22,7 @@ class LinearEffect(AbstractEffect):
 
     Parameters
     ----------
-    prior : None | Distribution, optional
+    prior : Distribution, optional
         A numpyro distribution to use as prior. Defaults to dist.Normal(0, 1)
     effect_mode : effects_application, optional
         Either "multiplicative" or "additive" by default "multiplicative".
@@ -28,8 +30,8 @@ class LinearEffect(AbstractEffect):
 
     def __init__(
         self,
-        prior: None | Distribution = None,
-        effect_mode: effects_application = "multiplicative",
+        prior: Optional[Distribution] = None,
+        effect_mode: EFFECT_APPLICATION_TYPE = "multiplicative",
         **kwargs,
     ):
         self.prior = prior or dist.Normal(0, 0.1)

--- a/src/prophetverse/effects/log.py
+++ b/src/prophetverse/effects/log.py
@@ -1,11 +1,13 @@
 """Definition of Log Effect class."""
 
+from typing import Optional
+
 import jax.numpy as jnp
 from numpyro import distributions as dist
 from numpyro.distributions import Distribution
 
 from prophetverse.effects.base import AbstractEffect
-from prophetverse.effects.effect_apply import effects_application
+from prophetverse.effects.effect_apply import EFFECT_APPLICATION_TYPE
 
 __all__ = ["LogEffect"]
 
@@ -15,9 +17,9 @@ class LogEffect(AbstractEffect):
 
     Parameters
     ----------
-    scale_prior : Distribution | None, optional
+    scale_prior : Optional[Distribution], optional
         The prior distribution for the scale parameter., by default Gamma
-    rate_prior : Distribution | None, optional
+    rate_prior : Optional[Distribution], optional
         The prior distribution for the rate parameter., by default Gamma
     effect_mode : effects_application, optional
         Either "additive" or "multiplicative", by default "multiplicative"
@@ -25,9 +27,9 @@ class LogEffect(AbstractEffect):
 
     def __init__(
         self,
-        scale_prior: Distribution | None = None,
-        rate_prior: Distribution | None = None,
-        effect_mode: effects_application = "multiplicative",
+        scale_prior: Optional[Distribution] = None,
+        rate_prior: Optional[Distribution] = None,
+        effect_mode: EFFECT_APPLICATION_TYPE = "multiplicative",
         **kwargs,
     ):
         self.scale_prior = scale_prior or dist.Gamma(1, 1)

--- a/src/prophetverse/utils/algebric_operations.py
+++ b/src/prophetverse/utils/algebric_operations.py
@@ -1,35 +1,37 @@
 """Functions that perform algebraic operations."""
 
+from typing import Union
+
 import jax.numpy as jnp
 from numpy.typing import NDArray
 
 
 def matrix_multiplication(
-    data: jnp.ndarray | NDArray, coefficients: jnp.ndarray | NDArray
-) -> jnp.ndarray | NDArray:
+    data: Union[jnp.ndarray, NDArray], coefficients: Union[jnp.ndarray, NDArray]
+) -> Union[jnp.ndarray, NDArray]:
     """Perform matrix multiplication between two matrixes.
 
     Parameters
     ----------
-    data : jnp.ndarray | NDArray
+    data : Union[jnp.ndarray, NDArray]
         Array to be multiplied.
-    coefficients : jnp.ndarray | NDArray
+    coefficients : Union[jnp.ndarray, NDArray]
         Array of coefficients used at matrix multiplication.
 
     Returns
     -------
-    jnp.ndarray | NDArray
+    Union[jnp.ndarray, NDArray]
         Matrix multiplication between data and coefficients.
     """
     return data @ coefficients.reshape((-1, 1))
 
 
-def _exponent_safe(data: jnp.ndarray | NDArray, exponent: float) -> jnp.ndarray:
+def _exponent_safe(data: Union[jnp.ndarray, NDArray], exponent: float) -> jnp.ndarray:
     """Exponentiate an array without numerical errors replacing zeros with ones.
 
     Parameters
     ----------
-    data : jnp.ndarray | NDArray
+    data : Union[jnp.ndarray, NDArray]
         Array to be exponentiated.
     exponent : float
         Expoent numerical value.


### PR DESCRIPTION
Removes "|" from type hints to avoid error raising in Python 3.9


Closes #79 