### PR TITLE
[FIX] Raise MAPInferenceEngineError if loss is nan

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,24 @@
+import jax.numpy as jnp
+import pytest
+from numpyro.infer.svi import SVIRunResult
+
+from prophetverse.engine import MAPInferenceEngine, MAPInferenceEngineError
+
+
+def test_raises_error_when_nan_loss():
+
+    bad_svi_result = SVIRunResult(
+        params={"param1": jnp.array([1, 2, 3])},
+        state=None,
+        losses=jnp.array([1, 2, jnp.nan]),
+    )
+
+    good_svi_result = SVIRunResult(
+        params={"param1": jnp.array([1, 2, 3])}, state=None, losses=jnp.array([1, 2, 3])
+    )
+
+    inf_engine = MAPInferenceEngine(lambda *args: None)
+
+    assert inf_engine.raise_error_if_nan_loss(good_svi_result) is None
+    with pytest.raises(MAPInferenceEngineError):
+        inf_engine.raise_error_if_nan_loss(bad_svi_result)


### PR DESCRIPTION
Add an exception to be raised when the optimization of MAP finds NaN values

Closes #39 