### PR TITLE
[DOC] Use mike to deploy versioned documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ jupytext = {version = "^1.16.3", optional = true}
 markdown-katex = {version = "^202406.1035", optional = true}
 python-markdown-math = {version = "^0.8", optional = true}
 tabulate = {version = "^0.9.0", optional = true}
+mike = {version = "^2.1.3", optional = true}
 
 
 [tool.poetry.extras]
@@ -57,7 +58,8 @@ dev = [
     "pydocstyle",
     "mypy",
     "pylint",
-    "mkdocstrings"
+    "mkdocstrings",
+    "mike",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This PR adds mike as a dependency, and the necessary configuration to use it for documentation deployment.