### PR TITLE
[MNT] Fix Dependabot failing CI pipelines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,4 +47,5 @@ jobs:
       with:
         files: ./coverage.xml
         fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Uses "env" to set codecov token
Tries to fix #122 