### PR TITLE
[ENH] HTML repr of BaseProphetForecaster

### DIFF
--- a/src/prophetverse/sktime/base.py
+++ b/src/prophetverse/sktime/base.py
@@ -933,8 +933,6 @@ class BaseProphetForecaster(_HeterogenousMetaEstimator, BaseBayesianForecaster):
     _steps_attr = "_exogenous_effects"
     _steps_fitted_attr = "exogenous_effects_"
 
-    _tags = {"visual_block_kind": "parallel"}
-
     def __init__(
         self,
         trend: Union[BaseEffect, str] = "linear",
@@ -983,12 +981,7 @@ class BaseProphetForecaster(_HeterogenousMetaEstimator, BaseBayesianForecaster):
             inference_engine=inference_engine,
         )
 
-    @property
-    def _trend(self):
-        """Return trend.
-
-        This property is for compatibility with _HeterogenousMetaEstimator.
-        """
+        self._trend = self._get_trend_model()
 
     @property
     def _exogenous_effects(self):
@@ -997,7 +990,7 @@ class BaseProphetForecaster(_HeterogenousMetaEstimator, BaseBayesianForecaster):
         This property is for compatibility with _HeterogenousMetaEstimator.
         """
         if self.exogenous_effects is None:
-            return [(None, None)]
+            return None
         return [(name, effect) for name, effect, _ in self.exogenous_effects]
 
     @_exogenous_effects.setter
@@ -1293,3 +1286,54 @@ class BaseProphetForecaster(_HeterogenousMetaEstimator, BaseBayesianForecaster):
             return new_obj.set_params(inference_engine=other)
 
         raise ValueError("Invalid type for right shift operator")
+
+    def _sk_visual_block_(self):
+        """
+        Implement visual block.
+
+        The try except is used since the methods used inside
+        _get_default_visual_block are private in sktime, and not public,
+        and may be changed in the future.
+        """
+        try:
+            # Tries to get the default visual block
+            return self._get_default_visual_block()
+
+        except Exception as e:
+            return super()._sk_visual_block_()
+
+    def _get_default_visual_block(self):
+        """Make default visual block."""
+        from sktime.utils._estimator_html_repr import _VisualBlock, _get_visual_block
+
+        visual_blocks = []
+        visual_block_names = []
+
+        steps = getattr(self, self._steps_attr)
+        steps = [("trend", self._trend)] + steps
+        names, estimators = zip(*steps)
+
+        name_details = [str(est) for est in estimators]
+
+        visual_blocks.append(
+            _VisualBlock(
+                "serial",
+                estimators,
+                names=names,
+                name_details=name_details,
+                dash_wrapped=False,
+            )
+        )
+        visual_block_names.append("effects")
+
+        inference_engine = self._inference_engine
+        visual_blocks.append(_get_visual_block(inference_engine))
+        visual_block_names.append("inference_engine")
+
+        return _VisualBlock(
+            "parallel",
+            visual_blocks,
+            names=visual_block_names,
+            name_details=[None] * len(visual_blocks),
+            dash_wrapped=False,
+        )

--- a/src/prophetverse/sktime/base.py
+++ b/src/prophetverse/sktime/base.py
@@ -933,6 +933,8 @@ class BaseProphetForecaster(_HeterogenousMetaEstimator, BaseBayesianForecaster):
     _steps_attr = "_exogenous_effects"
     _steps_fitted_attr = "exogenous_effects_"
 
+    _tags = {"visual_block_kind": "parallel"}
+
     def __init__(
         self,
         trend: Union[BaseEffect, str] = "linear",

--- a/src/prophetverse/sktime/base.py
+++ b/src/prophetverse/sktime/base.py
@@ -990,7 +990,7 @@ class BaseProphetForecaster(_HeterogenousMetaEstimator, BaseBayesianForecaster):
         This property is for compatibility with _HeterogenousMetaEstimator.
         """
         if self.exogenous_effects is None:
-            return None
+            return []
         return [(name, effect) for name, effect, _ in self.exogenous_effects]
 
     @_exogenous_effects.setter

--- a/src/prophetverse/sktime/base.py
+++ b/src/prophetverse/sktime/base.py
@@ -995,7 +995,7 @@ class BaseProphetForecaster(_HeterogenousMetaEstimator, BaseBayesianForecaster):
         This property is for compatibility with _HeterogenousMetaEstimator.
         """
         if self.exogenous_effects is None:
-            return []
+            return [(None, None)]
         return [(name, effect) for name, effect, _ in self.exogenous_effects]
 
     @_exogenous_effects.setter

--- a/src/prophetverse/sktime/multivariate.py
+++ b/src/prophetverse/sktime/multivariate.py
@@ -277,7 +277,7 @@ class HierarchicalProphet(BaseProphetForecaster):
             exogenous_data = {}
 
         # Trend model
-        self.trend_model_ = self._get_trend_model()
+        self.trend_model_ = self._trend.clone()
         self.trend_model_.fit(X=X_bottom, y=y_bottom, scale=self._scale)
         trend_data = self.trend_model_.transform(X=X_bottom, fh=fh)
 

--- a/src/prophetverse/sktime/univariate.py
+++ b/src/prophetverse/sktime/univariate.py
@@ -257,7 +257,7 @@ class Prophetverse(BaseProphetForecaster):
         """
         fh = y.index.get_level_values(-1).unique()
 
-        self.trend_model_ = self._get_trend_model()
+        self.trend_model_ = self._trend.clone()
 
         if self._likelihood_is_discrete:
             # Scale the data, since _get_fit_data receives


### PR DESCRIPTION
### Related issues
Fixes #167 

### What I changed
1. Added 'parallel' tag to `BaseProphetForecaster` where `_HeterogenousMetaEstimator` is inherited
![image](https://github.com/user-attachments/assets/f62769be-43c2-4810-a086-07f0daf7d522)

2. In case there are no exog effects, `_exogenous_effects` returns `[(None, None)]`. This part of the logic is something we can potentially change in `_HeterogenousMetaEstimator` in `sktime`
![image](https://github.com/user-attachments/assets/23ad6c57-218b-4892-941f-b81f9472f936)
