### PR TITLE
docs: update migration guide documentation

### DIFF
--- a/docs/migration guide.md
+++ b/docs/migration guide.md
@@ -1,0 +1,62 @@
+
+## Overview
+
+ This migration guide is intended for users familiar with `fbprophet` and outlines the key differences and necessary modifications for a seamless transition.
+
+## Verifying Installation
+
+Ensure that `prophetverse` is installed and accessible in your environment. To get started, follow the [installation guide](https://prophetverse.com/README.md/) for setting up Prophetverse.
+
+```python
+import prophetverse
+print(prophetverse.__version__)
+```
+
+## Key Differences
+
+### 1. Model Initialization
+
+|Task|`fbprophet`|`prophetverse`|
+|---|---|---|
+|Import|`from prophet import Prophet`|`from prophetverse.sktime import Prophetverse`|
+|Instantiate|`model = Prophet()`|`model = Prophetverse()`|
+
+### 2. Future DataFrame Creation
+
+Unlike `fbprophet`, `prophetverse` does not currently provide a built-in method for creating a future dataframe. This must be done manually:
+
+```python
+import pandas as pd
+
+future_dates = pd.date_range(start=data["ds"].max(), periods=30, freq="D")
+future = pd.DataFrame({"ds": future_dates})
+```
+
+### 3. Forecasting API
+
+The fitting and prediction interfaces remain largely unchanged:
+
+```python
+model.fit(data)
+forecast = model.predict(future)
+```
+
+### 4. Visualization
+
+Plotting methods from `fbprophet` remain consistent:
+
+```python
+model.plot(forecast)
+```
+
+## Summary of API Changes
+
+|Feature|`fbprophet`|`prophetverse`|
+|---|---|---|
+|Import path|`from prophet import Prophet`|`from prophetverse.sktime import Prophetverse`|
+|Future dataframe|`model.make_future_dataframe()`|Manual via `pd.date_range()`|
+|Prediction method|`model.predict()`|`model.predict()`|
+|Visualization|`model.plot()`|`model.plot()`|
+
+
+    

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ repo_url: https://github.com/felipeangelimvieira/prophetverse
 site_url: 'https://prophetverse.com/'
 nav:
   - Home: README.md
+  - Migration Guide: migration guide.md
   - Tutorial 📚:
       - Univariate Time Series: tutorial/univariate/index.md
       - Hierarchical Time Series: tutorial/hierarchical/index.md
@@ -74,6 +75,8 @@ nav:
 
 
 plugins:
+  - search
+
   - mkdocstrings:
       default_handler: python
       handlers:
@@ -81,10 +84,14 @@ plugins:
           paths: [src]
           options:
             docstring_style: numpy
-  - mkdocs-jupyter:
-      use_directory_urls: false
-  - ipymd:
-      nbconvert_template: docs/ipymd/custom-template.tpl
+
+  # - mkdocs-jupyter:
+  #     execute: false
+
+  # - ipymd:
+  #     nbconvert_template: docs/ipymd/custom-template.tpl
+
+
 
 markdown_extensions:
   - admonition

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,8 +75,6 @@ nav:
 
 
 plugins:
-  - search
-
   - mkdocstrings:
       default_handler: python
       handlers:
@@ -84,12 +82,10 @@ plugins:
           paths: [src]
           options:
             docstring_style: numpy
-
-  # - mkdocs-jupyter:
-  #     execute: false
-
-  # - ipymd:
-  #     nbconvert_template: docs/ipymd/custom-template.tpl
+  - mkdocs-jupyter:
+      use_directory_urls: false
+  - ipymd:
+      nbconvert_template: docs/ipymd/custom-template.tpl
 
 
 


### PR DESCRIPTION
This pull request introduces a new section (migration guide) to the  documentation. This guide is intended for those migrating from fbprophet to prophetverse, as discussed in issue #160. Please review the changes to ensure clarity and completeness.