### PR TITLE
[ENH] Add build_kernel method to MCMC engine to make it more modular

### DIFF
--- a/src/prophetverse/engine/mcmc.py
+++ b/src/prophetverse/engine/mcmc.py
@@ -81,9 +81,9 @@ class MCMCInferenceEngine(BaseInferenceEngine):
 
         super().__init__(rng_key)
 
-    def build_engine(self, model: Callable) -> MCMCKernel:
+    def build_kernel(self, model: Callable) -> MCMCKernel:
         """
-        Build the MCMC engine.
+        Builds the MCMC kernel.
 
         Parameters
         ----------
@@ -151,7 +151,7 @@ class MCMCInferenceEngine(BaseInferenceEngine):
 
             return flattened_samples, summary_
 
-        kernel_ = self.build_engine(self.model_)
+        kernel_ = self.build_kernel(self.model_)
         self.posterior_samples_, self.summary_ = get_posterior_samples(
             self._rng_key,
             kernel_,

--- a/src/prophetverse/engine/mcmc.py
+++ b/src/prophetverse/engine/mcmc.py
@@ -83,7 +83,7 @@ class MCMCInferenceEngine(BaseInferenceEngine):
 
     def build_kernel(self, model: Callable) -> MCMCKernel:
         """
-        Builds the MCMC kernel.
+        Build the MCMC kernel.
 
         Parameters
         ----------


### PR DESCRIPTION
This PR adresses:
1. Doc cleanup for MCMCInferenceEngine.
2. Type hinting.
3. Allows passing whether to use a progress bar or not.
4. Separates kernel building from that of sampling.

References #200 
