### PR TITLE
Migrate from `poetry` to `uv`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
         with:
           python-version: 3.x
 
-      - name: Install Poetry
-        run: pip install poetry
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Extract tag version
         run: echo "TAG_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
@@ -31,7 +31,7 @@ jobs:
 
       - name: Get current package version
         run: |
-          PACKAGE_VERSION=$(poetry version --short)
+          PACKAGE_VERSION=$(uv version --short)
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
 
       - name: Verify versions match
@@ -44,11 +44,12 @@ jobs:
       - name: Set version to match the release tag
         run: |
           echo "Setting package version to $TAG_VERSION"
-          poetry version "$TAG_VERSION"
+          uv version $TAG_VERSION
+          
+      - name: Build package
+        run: uv build --no-sources
 
       - name: Publish to PyPI
         env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          poetry build
-          poetry publish
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish --token $UV_PUBLISH_TOKEN

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# uv 
+uv.lock

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ cython_debug/
 
 # uv 
 uv.lock
+.python-version

--- a/README.md
+++ b/README.md
@@ -8,13 +8,10 @@
 [![PyPI version](https://badge.fury.io/py/prophetverse.svg)](https://badge.fury.io/py/prophetverse)
 [![codecov](https://codecov.io/gh/felipeangelimvieira/prophetverse/graph/badge.svg?token=O37PGJI3ZX)](https://codecov.io/gh/felipeangelimvieira/prophetverse)
 
-
-
 Prophetverse leverages the theory behind the Prophet model for time series forecasting and expands it into __a more general framework__, enabling custom priors, non-linear effects for exogenous variables and other likelihoods. Built on top of [sktime](https://www.sktime.net/en/stable/) and [numpyro](https://num.pyro.ai/en/stable/), Prophetverse aims to provide a flexible and easy-to-use library for time series forecasting with a focus on interpretability and customizability. It is particularly useful for Marketing Mix Modeling, where understanding the effect of different marketing channels on sales is crucial.
 
-
-
 ## Table of Contents
+
 - [🚀 Installation](#-installation)
 - [📊 Forecasting with default hyperparameters](#-forecasting-with-default-hyperparameters)
 - [🌟 Features & Comparison with Meta's Prophet](#-features--comparison-with-metas-prophet)
@@ -30,10 +27,10 @@ To install with pip:
 pip install prophetverse
 ```
 
-Or with poetry:
+Or with `uv`:
 
 ```bash
-poetry add prophetverse
+uv add prophetverse
 ```
 
 ## 📊 Forecasting with default hyperparameters
@@ -57,21 +54,18 @@ y_pred = model.predict(X=X, fh=[1,2,3,4])
 
 Prophetverse is similar to the original Prophet model in many aspects, but it has some differences and new features. The following table summarizes the main features of Prophetverse and compares them with the original Prophet model:
 
-
-
 | Feature                         | Prophetverse                                                                                                               | Original Prophet                         | Motivation |
 |---------------------------------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------------| ----------------------------------------- |
-| **Logistic trend**              | Capacity as a random variable                           | Capacity as a hyperparameter, user input required             | The capacity is usually unknown by the users. Having it as a variable is useful for Total Addressable Market inference |
-| **Custom trend**               | Customizable trend functions                                                                                                | Not available                            | Users can create custom trends and leverage their knowledge about the timeseries to enhance long-term accuracy |
-| **Likelihoods**                 | Gaussian, Gamma and Negative Binomial                                                                                                | Gaussian only                            | Gaussian likelihood fails to provide good forecasts to positive-only and count data (sales, for example) |
-| **Custom priors**               | Supports custom priors for model parameters and exogenous variables                                                        | Not supported                            | Forcing positive coefficients, using prior knowledge to model the timeseries|
-| **Custom exogenous effects**              | Non-linear and customizable effects for exogenous variables, shared coefficients between time series                       | Not available                            | Users can create any kind of relationship between exogenous variables and the timeseries, which can be useful for Marketing Mix Modeling and other applications. |
-| **Changepoints**                | Uses changepoint interval                                                                                                  | Uses changepoint number                  | The changepoint number is not stable in the sense that, when the size of timeseries increases, its impact on forecast changes. Think about setting a changepoint number when timeseries has 6 months, and forecasting in future with 2 years of data (4x time original size). Re-tuning would be required. Prophetverse is expected to be more stable |
-| **Scaling**                     | Time series scaled internally, exogenous variables scaled by the user                                                      | Time series scaled internally            | Scaling `y` is needed to enhance user experience with hyperparameters. On the other hand, not scaling the exogenous variables provide more control to the user and they can leverage sktime's transformers to handle that. |
-| **Seasonality**                 | Fourier terms for seasonality passed as exogenous variables                                                                | Built-in seasonality handling            | Setting up seasonality requires almost zero effort by using `LinearFourierSeasonality` in Prophetverse. The idea is to allow the user to create custom seasonalities easily, without hardcoding it in the code. |
-| **Multivariate model**          | Hierarchical model with multivariate normal likelihood and LKJ prior, bottom-up forecast                                    | Not available                            | Having shared coefficients, using global information to enhance individual forecast.|| **Inference methods**           | MCMC and MAP                                                                                                               | MCMC and MAP                            | |
-| **Implementation** | Numpyro | Stan
-
+| __Logistic trend__              | Capacity as a random variable                           | Capacity as a hyperparameter, user input required             | The capacity is usually unknown by the users. Having it as a variable is useful for Total Addressable Market inference |
+| __Custom trend__               | Customizable trend functions                                                                                                | Not available                            | Users can create custom trends and leverage their knowledge about the timeseries to enhance long-term accuracy |
+| __Likelihoods__                 | Gaussian, Gamma and Negative Binomial                                                                                                | Gaussian only                            | Gaussian likelihood fails to provide good forecasts to positive-only and count data (sales, for example) |
+| __Custom priors__               | Supports custom priors for model parameters and exogenous variables                                                        | Not supported                            | Forcing positive coefficients, using prior knowledge to model the timeseries|
+| __Custom exogenous effects__              | Non-linear and customizable effects for exogenous variables, shared coefficients between time series                       | Not available                            | Users can create any kind of relationship between exogenous variables and the timeseries, which can be useful for Marketing Mix Modeling and other applications. |
+| __Changepoints__                | Uses changepoint interval                                                                                                  | Uses changepoint number                  | The changepoint number is not stable in the sense that, when the size of timeseries increases, its impact on forecast changes. Think about setting a changepoint number when timeseries has 6 months, and forecasting in future with 2 years of data (4x time original size). Re-tuning would be required. Prophetverse is expected to be more stable |
+| __Scaling__                     | Time series scaled internally, exogenous variables scaled by the user                                                      | Time series scaled internally            | Scaling `y` is needed to enhance user experience with hyperparameters. On the other hand, not scaling the exogenous variables provide more control to the user and they can leverage sktime's transformers to handle that. |
+| __Seasonality__                 | Fourier terms for seasonality passed as exogenous variables                                                                | Built-in seasonality handling            | Setting up seasonality requires almost zero effort by using `LinearFourierSeasonality` in Prophetverse. The idea is to allow the user to create custom seasonalities easily, without hardcoding it in the code. |
+| __Multivariate model__          | Hierarchical model with multivariate normal likelihood and LKJ prior, bottom-up forecast                                    | Not available                            | Having shared coefficients, using global information to enhance individual forecast.|| __Inference methods__           | MCMC and MAP                                                                                                               | MCMC and MAP                            | |
+| __Implementation__ | Numpyro | Stan
 
 ## 🤝 Contributing to Prophetverse
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,10 +10,9 @@
 
 Prophetverse leverages the theory behind the Prophet model for time series forecasting and expands it into __a more general framework__, enabling custom priors, non-linear effects for exogenous variables and other likelihoods. Built on top of [sktime](https://www.sktime.net/en/stable/) and [numpyro](https://num.pyro.ai/en/stable/), Prophetverse aims to provide a flexible and easy-to-use library for time series forecasting with a focus on interpretability and customizability. It is particularly useful for Marketing Mix Modeling, where understanding the effect of different marketing channels on sales is crucial.
 
-
 <div class="grid cards" markdown>
 
--   :material-school:{ .lg .middle } __Theory__
+- :material-school:{ .lg .middle } __Theory__
 
     ---
 
@@ -21,7 +20,7 @@ Prophetverse leverages the theory behind the Prophet model for time series forec
 
     [:octicons-arrow-right-24: Read the post](the-theory)
 
--   :material-lightbulb-on:{ .lg .middle } __Basic examples__
+- :material-lightbulb-on:{ .lg .middle } __Basic examples__
 
     ---
 
@@ -29,7 +28,7 @@ Prophetverse leverages the theory behind the Prophet model for time series forec
 
     [:octicons-arrow-right-24: Examples](tutorial/univariate)
 
--   :material-cogs:{ .lg .middle } __Advanced examples__
+- :material-cogs:{ .lg .middle } __Advanced examples__
 
     ---
 
@@ -37,8 +36,7 @@ Prophetverse leverages the theory behind the Prophet model for time series forec
 
     [:octicons-arrow-right-24: How-to](howto/index.md)
 
-
--   :material-book-open-page-variant:{ .lg .middle } __Reference__
+- :material-book-open-page-variant:{ .lg .middle } __Reference__
 
     ---
 
@@ -46,10 +44,7 @@ Prophetverse leverages the theory behind the Prophet model for time series forec
 
     [:octicons-arrow-right-24: Reference](reference/sktime/prophetverse/)
 
-
 </div>
-
-
 
 ## Getting started
 
@@ -61,10 +56,10 @@ To install with pip:
 pip install prophetverse
 ```
 
-Or with poetry:
+Or with `uv`:
 
 ```bash
-poetry add prophetverse
+`uv` add prophetverse
 ```
 
 ### Forecasting with default values
@@ -85,24 +80,19 @@ model.fit(y=y, X=X)
 y_pred = model.predict(X=X, fh=y.index)
 ```
 
-
-
-
 ## Features
 
 Prophetverse is similar to the original Prophet model in many aspects, but it has some differences and new features. The following table summarizes the main features of Prophetverse and compares them with the original Prophet model:
 
-
-
 | Feature                         | Prophetverse                                                                                                               | Original Prophet                         | Motivation |
 |---------------------------------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------------| ----------------------------------------- |
-| **Logistic trend**              | Capacity as a random variable                           | Capacity as a hyperparameter, user input required             | The capacity is usually unknown by the users. Having it as a variable is useful for Total Addressable Market inference |
-| **Custom trend**               | Customizable trend functions                                                                                                | Not available                            | Users can create custom trends and leverage their knowledge about the timeseries to enhance long-term accuracy |
-| **Likelihoods**                 | Gaussian, Gamma and Negative Binomial                                                                                                | Gaussian only                            | Gaussian likelihood fails to provide good forecasts to positive-only and count data (sales, for example) |
-| **Custom priors**               | Supports custom priors for model parameters and exogenous variables                                                        | Not supported                            | Forcing positive coefficients, using prior knowledge to model the timeseries|
-| **Custom exogenous effects**              | Non-linear and customizable effects for exogenous variables, shared coefficients between time series                       | Not available                            | Users can create any kind of relationship between exogenous variables and the timeseries, which can be useful for Marketing Mix Modeling and other applications. |
-| **Changepoints**                | Uses changepoint interval                                                                                                  | Uses changepoint number                  | The changepoint number is not stable in the sense that, when the size of timeseries increases, its impact on forecast changes. Think about setting a changepoint number when timeseries has 6 months, and forecasting in future with 2 years of data (4x time original size). Re-tuning would be required. Prophetverse is expected to be more stable |
-| **Scaling**                     | Time series scaled internally, exogenous variables scaled by the user                                                      | Time series scaled internally            | Scaling `y` is needed to enhance user experience with hyperparameters. On the other hand, not scaling the exogenous variables provide more control to the user and they can leverage sktime's transformers to handle that. |
-| **Seasonality**                 | Fourier terms for seasonality passed as exogenous variables                                                                | Built-in seasonality handling            | Setting up seasonality requires almost zero effort by using `LinearFourierSeasonality` in Prophetverse. The idea is to allow the user to create custom seasonalities easily, without hardcoding it in the code. |
-| **Multivariate model**          | Hierarchical model with multivariate normal likelihood and LKJ prior, bottom-up forecast                                    | Not available                            | Having shared coefficients, using global information to enhance individual forecast.|| **Inference methods**           | MCMC and MAP                                                                                                               | MCMC and MAP                            | |
-| **Implementation** | Numpyro | Stan
+| __Logistic trend__              | Capacity as a random variable                           | Capacity as a hyperparameter, user input required             | The capacity is usually unknown by the users. Having it as a variable is useful for Total Addressable Market inference |
+| __Custom trend__               | Customizable trend functions                                                                                                | Not available                            | Users can create custom trends and leverage their knowledge about the timeseries to enhance long-term accuracy |
+| __Likelihoods__                 | Gaussian, Gamma and Negative Binomial                                                                                                | Gaussian only                            | Gaussian likelihood fails to provide good forecasts to positive-only and count data (sales, for example) |
+| __Custom priors__               | Supports custom priors for model parameters and exogenous variables                                                        | Not supported                            | Forcing positive coefficients, using prior knowledge to model the timeseries|
+| __Custom exogenous effects__              | Non-linear and customizable effects for exogenous variables, shared coefficients between time series                       | Not available                            | Users can create any kind of relationship between exogenous variables and the timeseries, which can be useful for Marketing Mix Modeling and other applications. |
+| __Changepoints__                | Uses changepoint interval                                                                                                  | Uses changepoint number                  | The changepoint number is not stable in the sense that, when the size of timeseries increases, its impact on forecast changes. Think about setting a changepoint number when timeseries has 6 months, and forecasting in future with 2 years of data (4x time original size). Re-tuning would be required. Prophetverse is expected to be more stable |
+| __Scaling__                     | Time series scaled internally, exogenous variables scaled by the user                                                      | Time series scaled internally            | Scaling `y` is needed to enhance user experience with hyperparameters. On the other hand, not scaling the exogenous variables provide more control to the user and they can leverage sktime's transformers to handle that. |
+| __Seasonality__                 | Fourier terms for seasonality passed as exogenous variables                                                                | Built-in seasonality handling            | Setting up seasonality requires almost zero effort by using `LinearFourierSeasonality` in Prophetverse. The idea is to allow the user to create custom seasonalities easily, without hardcoding it in the code. |
+| __Multivariate model__          | Hierarchical model with multivariate normal likelihood and LKJ prior, bottom-up forecast                                    | Not available                            | Having shared coefficients, using global information to enhance individual forecast.|| __Inference methods__           | MCMC and MAP                                                                                                               | MCMC and MAP                            | |
+| __Implementation__ | Numpyro | Stan

--- a/docs/development/development-guide.md
+++ b/docs/development/development-guide.md
@@ -1,6 +1,7 @@
 Contributing to Prophetverse
 
 ## Finding an issue to contribute to
+
 If you are brand new to Prophetverse or open-source development, we recommend searching the [GitHub “issues” tab](https://github.com/felipeangelimvieira/prophetverse/issues) to find issues that interest you. Unassigned issues labeled Docs and good first issue are typically good for newer contributors.
 
 Once you’ve found an interesting issue, it’s a good idea to assign the issue to yourself, so nobody else duplicates the work on it. On the Github issue, a comment with the exact text take to automatically assign you the issue (this will take seconds and may require refreshing the page to see it).
@@ -9,7 +10,7 @@ If for whatever reason you are not able to continue working with the issue, plea
 
 ## Tips for a successful pull request
 
-If you have made it to the Making a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) phase, one of the core contributors may take a look. 
+If you have made it to the Making a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) phase, one of the core contributors may take a look.
 
 ## What is a good pull request?
 
@@ -24,35 +25,40 @@ If you have made it to the Making a [pull request](https://docs.github.com/en/pu
 - Keep Updating your pull request, either by request or every few days
 
 ## Creating a development environment
+
 1. Step 1: [install python](https://wiki.python.org/moin/BeginnersGuide)
 
-2. Step 1: [install poetry](https://python-poetry.org/docs/)
-3. Step 2: install dev dependencies
-    <br> ``` poetry install --extras dev ``` </br>
-
+2. Step 1: [install `uv`](https://docs.astral.sh/uv/getting-started/installation/)
+3. Step 2: install dependencies (including `dev` dependencies) with `uv`:
+    <br> ```uv sync``` </br>
 
 ## Contributing to the documentation
+
 Contributing to the documentation benefits everyone who uses Prophetverse. We encourage you to help us improve the documentation, and you don’t have to be an expert on Prophetverse to do so! In fact, there are sections of the docs that are worse off after being written by experts. If something in the docs doesn’t make sense to you, updating the relevant section after you figure it out is a great way to ensure it will help the next person.
 
-## About the documentation:
-The documentation is written in [mkdocs](https://www.mkdocs.org/), you can learn more at [mkdocs getting started guide](https://www.mkdocs.org/getting-started/). 
-    
-## Contributor community :
-Community slack: None yet. 
+## About the documentation
+
+The documentation is written in [mkdocs](https://www.mkdocs.org/), you can learn more at [mkdocs getting started guide](https://www.mkdocs.org/getting-started/).
+
+## Contributor community
+
+Community slack: None yet.
 
 ## Contributing to the code base
+
 ### Code standards
+
 Writing good code is not just about what you write. It is also about how you write it. During Continuous Integration testing, several tools will be run to check your code for stylistic errors. Generating any warnings will cause the test to fail. Thus, good style is a requirement for submitting code to Prophetverse.There are of tools in Prophetverse to help contributors verify their changes before contributing to the project
 
-#### [Pytest](https://docs.pytest.org/en/7.1.x/contents.html) 
-You can test your code with pytest integration with the poetry command
-<br> ```poetry run pytest```
+#### [Pytest](https://docs.pytest.org/en/7.1.x/contents.html)
 
-The CI tests are computationally intensive, so if you want to do a faster test you can run a [smoke test](https://en.wikipedia.org/wiki/Smoke_testing_(software)) with the command 
-<br> ```poetry run pytest -m "not ci"```
+You can test your code with pytest integration with this `uv` command
+<br> ```uv run pytest```
+
+The CI tests are computationally intensive, so if you want to do a faster test you can run a [smoke test](https://en.wikipedia.org/wiki/Smoke_testing_(software)) with the command
+<br> ```uv run pytest -m "not ci"```
 
 If you also wanna run the tests even faster feel free to parallel processing the tests with [pytest-xdist](https://pytest-xdist.readthedocs.io/en/latest/how-to.html#making-session-scoped-fixtures-execute-only-once).
-
 
 #### [Pre-commit](https://pre-commit.com/)
 
@@ -68,8 +74,8 @@ Note that if needed, you can skip these checks with git commit --no-verify.
 
 If you don’t want to use pre-commit as part of your workflow, you can still use it to run its checks with one of the following:
 
-<br> ``` pre-commit run --files <files you have modified> ``` </br> 
-<br> ``` pre-commit run --from-ref=upstream/main --to-ref=HEAD --all-files ``` </br> 
+<br> ``` pre-commit run --files <files you have modified> ``` </br>
+<br> ``` pre-commit run --from-ref=upstream/main --to-ref=HEAD --all-files ``` </br>
 
 without needing to have done pre-commit install beforehand.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,74 +1,61 @@
-[tool.poetry]
+[project]
 name = "prophetverse"
 version = "0.6.0"
 description = "A multiverse of prophet models, for forecasting and Marketing Mix Modeling."
-authors = ["Felipe Angelim <felipeangelim@gmail.com>"]
+authors = [{ name = "Felipe Angelim", email = "felipeangelim@gmail.com" }]
+requires-python = ">=3.9, <3.13"
 readme = "README.md"
-packages = [{ include = "prophetverse", from="src"}]
-
-[tool.poetry.dependencies]
-python = ">=3.9, <3.13"
-sktime = ">=0.30.0"
-numpyro = "<0.18"
-optax = ">=0.2"
-graphviz = "^0.20.3"
-scikit-base = "^0.12.0"
-skpro = "^2.8.0"
-
-ipykernel = { version = ">=6.26.0,<7.0.0", optional = true }
-pytest = { version = ">=8.0.0,<9.0.0", optional = true }
-sphinx = { version = ">=7.2.6,<8.0.0", optional = true }
-matplotlib = { version = ">=3.8.2,<4.0.0", optional = true }
-mkdocs = { version = ">=1.5.3,<2.0.0", optional = true }
-mkdocstrings-python = { version = ">=1.9.0,<2.0.0", optional = true }
-mkdocs-jupyter = { version = ">=0.24.6,<0.26.0", optional = true }
-pymdown-extensions = { version = ">=10.7.1,<11.0.0", optional = true }
-mkdocs-material = { version = ">=9.5.14,<10.0.0", optional = true }
-pytest-cov = { version = ">=5.0.0,<7.0.0", optional = true }
-pre-commit = { version = ">=3.7.1,<5.0.0", optional = true }
-commitlint = { version = ">=1.0.0,<2.0.0", optional = true }
-black = { version = ">=24.4.2,<26.0.0", optional = true }
-isort = { version = ">=5.13.2,<7.0.0", optional = true }
-pydocstyle = { version = ">=6.3.0,<7.0.0", optional = true }
-mypy = { version = ">=1.10.0,<2.0.0", optional = true }
-pylint = { version = ">=3.2.2,<4.0.0", optional = true }
-mkdocstrings = { version = "^0.28.1", optional = true }
-jupytext = {version = "^1.16.3", optional = true}
-markdown-katex = {version = "^202406.1035", optional = true}
-python-markdown-math = {version = "^0.8", optional = true}
-tabulate = {version = "^0.9.0", optional = true}
-mike = {version = "^2.1.3", optional = true}
-mkdocs-ipymd = {version = "^0.0.4", optional = true}
-seaborn = {version = "^0.13.2", optional = true}
-statsmodels = {version = "^0.14.4", optional = true}
-
-
-
-[tool.poetry.extras]
-dev = [
-    "ipykernel",
-    "pytest",
-    "sphinx",
-    "matplotlib",
-    "mkdocs",
-    "mkdocstrings-python",
-    "mkdocs-jupyter",
-    "pymdown-extensions",
-    "mkdocs-material",
-    "pytest-cov",
-    "pre-commit",
-    "commitlint",
-    "isort",
-    "black",
-    "pydocstyle",
-    "mypy",
-    "pylint",
-    "mkdocstrings",
-    "mike",
-    "seaborn",
-    "statsmodels",
-    "mkdocs-ipymd",
+dependencies = [
+    "sktime>=0.30.0",
+    "numpyro<0.18",
+    "optax>=0.2",
+    "graphviz>=0.20.3,<0.21",
+    "scikit-base>=0.12.0,<0.13",
+    "skpro>=2.8.0,<3",
+    "jupytext>=1.16.3,<2",
+    "markdown-katex~=202406.1035",
+    "python-markdown-math>=0.8,<0.9",
+    "tabulate>=0.9.0,<0.10",
 ]
+
+[project.optional-dependencies]
+dev = [
+    "ipykernel>=6.26.0,<7.0.0",
+    "pytest>=8.0.0,<9.0.0",
+    "sphinx>=7.2.6,<8.0.0",
+    "matplotlib>=3.8.2,<4.0.0",
+    "mkdocs>=1.5.3,<2.0.0",
+    "mkdocstrings-python>=1.9.0,<2.0.0",
+    "mkdocs-jupyter>=0.24.6,<0.26.0",
+    "pymdown-extensions>=10.7.1,<11.0.0",
+    "mkdocs-material>=9.5.14,<10.0.0",
+    "pytest-cov>=5.0.0,<7.0.0",
+    "pre-commit>=3.7.1,<5.0.0",
+    "commitlint>=1.0.0,<2.0.0",
+    "isort>=5.13.2,<7.0.0",
+    "black>=24.4.2,<26.0.0",
+    "pydocstyle>=6.3.0,<7.0.0",
+    "mypy>=1.10.0,<2.0.0",
+    "pylint>=3.2.2,<4.0.0",
+    "mkdocstrings>=0.28.1,<0.29",
+    "mike>=2.1.3,<3",
+    "seaborn>=0.13.2,<0.14",
+    "statsmodels>=0.14.4,<0.15",
+    "mkdocs-ipymd>=0.0.4,<0.0.5",
+]
+
+[tool.hatch.build.targets.sdist]
+include = ["src/prophetverse"]
+
+[tool.hatch.build.targets.wheel]
+include = ["src/prophetverse"]
+
+[tool.hatch.build.targets.wheel.sources]
+"src/prophetverse" = "prophetverse"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
 log_cli = true
@@ -76,10 +63,5 @@ markers = [
     "ci: marks tests for Continuous Integration",
     "smoke: marks tests for smoke testing",
     ]
-
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
 
 [tool.pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "tabulate>=0.9.0,<0.10",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "ipykernel>=6.26.0,<7.0.0",
     "pytest>=8.0.0,<9.0.0",


### PR DESCRIPTION
Closes #209 

This PR introduces `uv` for project and dependency management. Motivation for this change is highlighted in #209.

Note that all changes except for `release.yml` have been tested locally. Best efforts in migrating `release.yml` have been taken, but I cannot ensure correctness (e.g. the release process).