### PR TITLE
datetime error handling

### DIFF
--- a/src/prophetverse/sktime/univariate.py
+++ b/src/prophetverse/sktime/univariate.py
@@ -186,6 +186,7 @@ class Prophetverse(BaseProphetForecaster):
             Dictionary containing prepared data for model fitting.
         """
         fh = y.index.get_level_values(-1).unique()
+        fh = pd.Index(list(fh.to_numpy()))
 
         self.trend_model_ = self._trend.clone()
         self.likelihood_model_ = self._likelihood.clone()

--- a/src/prophetverse/utils/frame_to_array.py
+++ b/src/prophetverse/utils/frame_to_array.py
@@ -9,6 +9,7 @@ from jax import numpy as jnp
 from .multiindex import iterate_all_series
 
 NANOSECONDS_TO_SECONDS = 1000 * 1000 * 1000
+PANDAS_DATETIME_NS = 'datetime64[ns]'
 
 __all__ = [
     "convert_index_to_days_since_epoch",
@@ -33,6 +34,9 @@ def convert_index_to_days_since_epoch(idx: pd.Index) -> np.array:
         The converted array of days since epoch.
     """
     t = idx
+
+    if t.dtype != PANDAS_DATETIME_NS:
+        t = t.astype(PANDAS_DATETIME_NS)
 
     if not (isinstance(t, pd.PeriodIndex) or isinstance(t, pd.DatetimeIndex)):
         return t.values


### PR DESCRIPTION
- Ensure datetime index is converted to datetime64[ns] to avoid incorrect time resolution (e.g. when t is not in nanoseconds).

- Align behaviour between . _get_fit_data() and ._get_predict_data():
   - The former did not correct frequency of datetime index (fh = y.index.get_level_values(-1).unique())
   - The latter did (fh_dates = self.fh_to_index(fh) → pd.Index(list(fh_dates.to_numpy()))).

- I have added a step in convert_index_to_days_since_epoch (frame_to_array.py) to ensure the index is in NANOSECONDS.
   - The univariate Prophetverse class doesn't pass its "fh variable" to the exogenous variables - that's why I added this. Those datetime indeces will still need to be set to NANOSECONDS.