### PR TITLE
[ENH] Add active period parameters to LinearFourierSeasonality and tests

### DIFF
--- a/tests/effects/test_fourier.py
+++ b/tests/effects/test_fourier.py
@@ -1,5 +1,6 @@
 import jax.numpy as jnp
 import numpyro
+import numpy as np
 import pandas as pd
 import pytest
 from sktime.transformations.series.fourier import FourierFeatures
@@ -9,12 +10,18 @@ from prophetverse.effects import LinearEffect, LinearFourierSeasonality
 
 @pytest.fixture
 def exog_data():
+    # Longer period for more comprehensive testing
     return pd.DataFrame(
         {
-            "date": pd.date_range("2021-01-01", periods=10),
-            "value": range(10),
+            "date": pd.date_range("2021-01-01", periods=40, freq="D"),
+            "value": range(40),
         }
     ).set_index("date")
+
+
+@pytest.fixture
+def y_data(exog_data):
+    return pd.DataFrame({"y": np.random.rand(len(exog_data))}, index=exog_data.index)
 
 
 @pytest.fixture
@@ -28,12 +35,26 @@ def fourier_effect_instance():
     )
 
 
+@pytest.fixture
+def fourier_effect_instance_config():
+    # Config for typical tests, weekly seasonality
+    return {
+        "sp_list": [7],
+        "fourier_terms_list": [3],
+        "freq": "D",
+        "prior_scale": 1.0,
+        "effect_mode": "additive",
+    }
+
+
 def test_linear_fourier_seasonality_initialization(fourier_effect_instance):
     assert fourier_effect_instance.sp_list == [365.25]
     assert fourier_effect_instance.fourier_terms_list == [3]
     assert fourier_effect_instance.freq == "D"
     assert fourier_effect_instance.prior_scale == 1.0
     assert fourier_effect_instance.effect_mode == "additive"
+    assert fourier_effect_instance.active_period_start is None
+    assert fourier_effect_instance.active_period_end is None
 
 
 def test_linear_fourier_seasonality_fit(fourier_effect_instance, exog_data):
@@ -65,3 +86,58 @@ def test_linear_fourier_seasonality_predict(fourier_effect_instance, exog_data):
         )
     assert prediction is not None
     assert isinstance(prediction, jnp.ndarray)
+
+
+def test_active_period_middle(fourier_effect_instance_config, exog_data, y_data):
+    start_date = pd.to_datetime("2021-01-10")
+    end_date = pd.to_datetime("2021-01-20")
+    
+    effect = LinearFourierSeasonality(
+        **fourier_effect_instance_config,
+        active_period_start=start_date,
+        active_period_end=end_date
+    )
+    effect.fit(X=exog_data, y=y_data)
+    transformed_effect = effect.transform(X=exog_data, fh=exog_data.index)
+
+    assert isinstance(transformed_effect, jnp.ndarray)
+    
+    before_mask = exog_data.index < start_date
+    during_mask = (exog_data.index >= start_date) & (exog_data.index <= end_date)
+    after_mask = exog_data.index > end_date
+
+    assert jnp.all(transformed_effect[before_mask] == 0), "Effect should be zero before active period"
+    # Sum of absolute values to check for non-zero, as individual terms can be zero
+    assert jnp.sum(jnp.abs(transformed_effect[during_mask])) > 1e-6, "Effect should be non-zero during active period"
+    assert jnp.all(transformed_effect[after_mask] == 0), "Effect should be zero after active period"
+
+
+def test_active_period_start_only(fourier_effect_instance_config, exog_data, y_data):
+    start_date = pd.to_datetime("2021-01-15")
+    effect = LinearFourierSeasonality(
+        **fourier_effect_instance_config,
+        active_period_start=start_date
+    )
+    effect.fit(X=exog_data, y=y_data)
+    transformed_effect = effect.transform(X=exog_data, fh=exog_data.index)
+
+    before_mask = exog_data.index < start_date
+    during_mask = exog_data.index >= start_date
+    
+    assert jnp.all(transformed_effect[before_mask] == 0)
+    assert jnp.sum(jnp.abs(transformed_effect[during_mask])) > 1e-6
+
+def test_active_period_end_only(fourier_effect_instance_config, exog_data, y_data):
+    end_date = pd.to_datetime("2021-01-15")
+    effect = LinearFourierSeasonality(
+        **fourier_effect_instance_config,
+        active_period_end=end_date
+    )
+    effect.fit(X=exog_data, y=y_data)
+    transformed_effect = effect.transform(X=exog_data, fh=exog_data.index)
+
+    during_mask = exog_data.index <= end_date
+    after_mask = exog_data.index > end_date
+
+    assert jnp.sum(jnp.abs(transformed_effect[during_mask])) > 1e-6
+    assert jnp.all(transformed_effect[after_mask] == 0)


### PR DESCRIPTION
This pull request introduces enhancements to the `LinearFourierSeasonality` class in the `prophetverse` library, adding functionality to define active periods for seasonality effects. It also updates the test suite to validate these new features. The most significant changes include the addition of `active_period_start` and `active_period_end` parameters, modifications to the `_transform` method to apply masking based on active periods, and new test cases to ensure correct behavior.

### Enhancements to `LinearFourierSeasonality` functionality:
* Added `active_period_start` and `active_period_end` parameters to specify the period during which the seasonality effect is active. These parameters are optional and default to `None`. (`src/prophetverse/effects/fourier.py`, [[1]](diffhunk://#diff-cbbd03608a4761f6bf816b000eb13bc49dcfb4c0f8c82a30e01b14b0cd40f173R35-R40) [[2]](diffhunk://#diff-cbbd03608a4761f6bf816b000eb13bc49dcfb4c0f8c82a30e01b14b0cd40f173R59-R68)
* Updated the `_transform` method to apply a mask based on the active period, ensuring the effect is only applied within the specified time range. (`src/prophetverse/effects/fourier.py`, [src/prophetverse/effects/fourier.pyR137-R156](diffhunk://#diff-cbbd03608a4761f6bf816b000eb13bc49dcfb4c0f8c82a30e01b14b0cd40f173R137-R156))

### Updates to the test suite:
* Extended the `exog_data` fixture to cover a longer time range for more comprehensive testing. (`tests/effects/test_fourier.py`, [tests/effects/test_fourier.pyR13-R26](diffhunk://#diff-928776bb54163d61c3d8948ddcd9f8472d614567d12b6163919a4dd921910670R13-R26))
* Added new test cases to validate the behavior of active periods:
  - [`test_active_period_middle`](diffhunk://#diff-928776bb54163d61c3d8948ddcd9f8472d614567d12b6163919a4dd921910670R89-R143): Verifies the effect is active only within the specified start and end dates. (`tests/effects/test_fourier.py`, [tests/effects/test_fourier.pyR89-R143](diffhunk://#diff-928776bb54163d61c3d8948ddcd9f8472d614567d12b6163919a4dd921910670R89-R143))
  - [`test_active_period_start_only`](diffhunk://#diff-928776bb54163d61c3d8948ddcd9f8472d614567d12b6163919a4dd921910670R89-R143): Ensures the effect is active from a specified start date onward. (`tests/effects/test_fourier.py`, [tests/effects/test_fourier.pyR89-R143](diffhunk://#diff-928776bb54163d61c3d8948ddcd9f8472d614567d12b6163919a4dd921910670R89-R143))
  - [`test_active_period_end_only`](diffhunk://#diff-928776bb54163d61c3d8948ddcd9f8472d614567d12b6163919a4dd921910670R89-R143): Confirms the effect is active up to a specified end date. (`tests/effects/test_fourier.py`, [tests/effects/test_fourier.pyR89-R143](diffhunk://#diff-928776bb54163d61c3d8948ddcd9f8472d614567d12b6163919a4dd921910670R89-R143))