### PR TITLE
[ENH] Add automated tests for target effects

### DIFF
--- a/tests/effects/test_all_target_likelihoods.py
+++ b/tests/effects/test_all_target_likelihoods.py
@@ -1,0 +1,48 @@
+from skbase.testing.test_all_objects import TestAllObjects, BaseFixtureGenerator
+from prophetverse.effects.target.base import BaseTargetEffect
+import jax.numpy as jnp
+import numpyro
+from sktime.utils._testing.series import _make_series
+
+
+class TargetEffectFixtureGenerator(BaseFixtureGenerator):
+    """Fixture for testing all target likelihoods."""
+
+    package_name = "prophetverse.effects.target"
+    object_type_filter = BaseTargetEffect
+
+
+class TestAllTargetEffects(TargetEffectFixtureGenerator, TestAllObjects):
+
+    valid_tags = [
+        "capability:panel",
+        "capability:multivariate_input",
+        "requires_X",
+        "applies_to",
+        "filter_indexes_with_forecating_horizon_at_transform",
+        "requires_fit_before_transform",
+        "fitted_named_object_parameters",
+        "named_object_parameters",
+    ]
+
+    def test_applies_to_tag(self, object_instance):
+        assert object_instance.get_tag("applies_to", None) == "y"
+
+    def test_fit_transform_predict_sites(self, object_instance):
+        """Test site names and no exceptions"""
+        y = _make_series(50).to_frame("value")
+        object_instance.fit(y=y, X=None)
+
+        data = object_instance.transform(y, fh=y.index)
+
+        predicted_effects = {
+            "trend": jnp.ones(len(y)) * 0.5,
+        }
+        with numpyro.handlers.seed(rng_seed=42):
+            with numpyro.handlers.trace() as trace:
+                predictions = object_instance.predict(data, predicted_effects)
+
+        assert "obs" in trace
+        assert trace["obs"]["is_observed"]
+        assert all(trace["obs"]["value"].flatten() == y.values.flatten())
+        assert "mean" in trace


### PR DESCRIPTION
Add automatic tests for new target effects
This pull request introduces a new test suite for validating all target likelihood implementations in the `prophetverse.effects.target` package. The changes include a new fixture generator and test class to ensure compatibility and correctness of target effects.

### Additions to testing framework:

* [`tests/effects/test_all_target_likelihoods.py`](diffhunk://#diff-7ee49798e064490af0bc30c0d700c4b37910bbe57026948e46d2149aa622fb28R1-R48): Added a `TargetEffectFixtureGenerator` class to generate test fixtures for objects of type `BaseTargetEffect` in the `prophetverse.effects.target` package. This ensures comprehensive testing of all target likelihoods.

* [`tests/effects/test_all_target_likelihoods.py`](diffhunk://#diff-7ee49798e064490af0bc30c0d700c4b37910bbe57026948e46d2149aa622fb28R1-R48): Introduced a `TestAllTargetEffects` class that inherits from `TargetEffectFixtureGenerator` and `TestAllObjects`, with tests for specific tags (e.g., "applies_to") and functionality like `fit`, `transform`, and `predict`. This validates site names, prediction correctness, and ensures no exceptions occur during operations.