### PR TITLE
[ENH] Extend `set_params` and `get_params` to handle numpyro's distributions

### DIFF
--- a/src/prophetverse/effects/base.py
+++ b/src/prophetverse/effects/base.py
@@ -8,7 +8,8 @@ from skbase.base import BaseObject
 import numpyro
 from prophetverse.utils.deprecation import deprecation_warning
 from prophetverse.utils import series_to_tensor_or_array
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
+import copy
 
 __all__ = ["BaseEffect", "BaseAdditiveOrMultiplicativeEffect"]
 
@@ -466,6 +467,51 @@ class BaseEffect(BaseObject):
                 "Please call the parameters directly from _predict using"
                 "numpyro.sample as you would call numpyro.sample",
             )
+
+    def _get_distribution_params(self, params):
+
+        distribution_params = {}
+        for param_name, param_value in params.items():
+            if isinstance(param_value, numpyro.distributions.Distribution):
+                # Get init args of param_value
+                init_args = param_value.__init__.__code__.co_varnames[1:]
+                for argname in init_args:
+                    distribution_params[param_name + "__" + argname] = getattr(
+                        param_value, argname
+                    )
+        return distribution_params
+
+    def get_params(self, deep=True):
+        params = super().get_params(deep=deep)
+        if not deep:
+            return params
+        new_params = self._get_distribution_params(params)
+        return {**params, **new_params}
+
+    def set_params(self, **params):
+
+        all_params = self.get_params(deep=False)
+        distribution_params = self._get_distribution_params(all_params)
+
+        distribution_params_to_update = defaultdict(dict)
+        for param_name, param_value in params.items():
+            if param_name in distribution_params:
+                base_param_name, distribution_argname = param_name.split("__")
+                distribution_params_to_update[base_param_name] = {
+                    **distribution_params_to_update[base_param_name],
+                    distribution_argname: param_value,
+                }
+
+        for param_to_update, distribution_args in distribution_params_to_update.items():
+            distribution_obj = copy.deepcopy(getattr(self, param_to_update))
+            for argname, value in distribution_args.items():
+                setattr(distribution_obj, argname, value)
+            self.set_params(**{param_to_update: distribution_obj})
+
+        not_distribution_params = {
+            k: v for k, v in params.items() if k not in distribution_params
+        }
+        return super().set_params(**not_distribution_params)
 
 
 class BaseAdditiveOrMultiplicativeEffect(BaseEffect):

--- a/tests/effects/test_base.py
+++ b/tests/effects/test_base.py
@@ -16,6 +16,19 @@ class ConcreteEffect(BaseAdditiveOrMultiplicativeEffect):
         return jnp.mean(data, axis=1, keepdims=True)
 
 
+DEFAULT_DIST = dist.Normal(0, 1)
+
+
+class EffectWithDistribution(BaseEffect):
+
+    def __init__(self, dist=None):
+        """Initialize effect with a distribution."""
+        self.dist = dist
+        super().__init__()
+
+        self._dist = self.dist if dist is not None else DEFAULT_DIST
+
+
 @pytest.fixture(name="effect_with_regex")
 def effect_with_regex():
     """Most simple class of abstracteffect with optional regex."""
@@ -139,3 +152,24 @@ def test_update_data():
 
     with pytest.raises(ValueError):
         effect._update_data("error", data_out)
+
+
+def test_get_params():
+    """
+    Test get params with distribution params
+    """
+
+    effect = EffectWithDistribution()
+    assert len(effect.get_params(True)) == 1
+
+    laplace = dist.Laplace(0, 1)
+    effect.set_params(**{"dist": laplace})
+    assert len(effect.get_params()) == 5
+
+    effect.set_params(**{"dist__loc": 10, "dist__scale": 2})
+    params = effect.get_params()
+    assert effect.dist != laplace
+    assert params["dist__loc"] == 10
+    assert params["dist__scale"] == 2
+    assert effect.dist.loc == 10
+    assert effect.dist.scale == 2


### PR DESCRIPTION
Although numpyro distributions are not estimators, it would be really helpful if we could set the prior parameters through `set_params` API, so that the prior hyperparameters can be plugged into hyperparameter tuning pipelines.

This PR Add this feature.

Closes #244 