### PR TITLE
[BUG] Make it possible for adstock to be used afterwards without problems

### DIFF
--- a/src/prophetverse/effects/adstock.py
+++ b/src/prophetverse/effects/adstock.py
@@ -123,7 +123,10 @@ class GeometricAdstockEffect(BaseEffect):
         jnp.ndarray
             An array with shape (T, 1) for univariate timeseries.
         """
-        data, ix = data
+        if isinstance(data, tuple):
+            data, ix = data
+        elif isinstance(data, (jnp.ndarray)):
+            ix = jnp.arange(data.shape[0], dtype=jnp.int32)
 
         decay = numpyro.sample("decay", self._decay_prior)
 

--- a/src/prophetverse/effects/chain.py
+++ b/src/prophetverse/effects/chain.py
@@ -123,4 +123,10 @@ class ChainedEffects(BaseMetaEstimatorMixin, BaseEffect):
                     ("linear", LinearEffect()),
                 ]
             },
+            {
+                "steps": [
+                    ("linear", LinearEffect()),
+                    ("adstock", GeometricAdstockEffect()),
+                ]
+            },
         ]


### PR DESCRIPTION
Closes #259 
Adstock is currently breaking if used as a post-process step in chainedeffects.