### PR TITLE
[FIX] Update import for _get_s_matrix based on sktime version

### DIFF
--- a/src/prophetverse/utils/multiindex.py
+++ b/src/prophetverse/utils/multiindex.py
@@ -1,7 +1,13 @@
 """Utilities for working with multi-indexed DataFrames."""
 
 import pandas as pd
-from sktime.transformations.hierarchical.reconcile import _get_s_matrix
+from sktime import __version__
+
+if __version__ < "0.37.1":
+    from sktime.transformations.hierarchical.reconcile import _get_s_matrix
+else:
+    from sktime.transformations.hierarchical.reconcile._reconcile import _get_s_matrix
+
 
 __all__ = [
     "get_bottom_series_idx",


### PR DESCRIPTION
Closes #262 

sktime version 0.37.1 changes the structure of the reconciliation module and `_get_s_matrix` is now moved to `._reconcile`.