### PR TITLE
[ENH] Forward effect

### DIFF
--- a/src/prophetverse/__init__.py
+++ b/src/prophetverse/__init__.py
@@ -20,6 +20,7 @@ from .effects import (
     GeometricAdstockEffect,
     WeibullAdstockEffect,
     ChainedEffects,
+    Forward,
 )
 from .engine import (
     MAPInferenceEngine,
@@ -93,4 +94,5 @@ __all__ = [
     "TotalInvestmentTransform",
     "InvestmentPerSeries",
     "IdentityTransform",
+    "Forward",
 ]

--- a/src/prophetverse/effects/__init__.py
+++ b/src/prophetverse/effects/__init__.py
@@ -18,6 +18,7 @@ from .target.univariate import (
     NegativeBinomialTargetLikelihood,
     BetaTargetLikelihood,
 )
+from .forward import Forward
 from .trend import PiecewiseLinearTrend, PiecewiseLogisticTrend, FlatTrend
 
 __all__ = [
@@ -41,4 +42,5 @@ __all__ = [
     "PiecewiseLinearTrend",
     "PiecewiseLogisticTrend",
     "FlatTrend",
+    "Forward",
 ]

--- a/src/prophetverse/effects/forward.py
+++ b/src/prophetverse/effects/forward.py
@@ -1,0 +1,52 @@
+"""Constant effect module."""
+
+import jax.numpy as jnp
+import numpyro
+import numpyro.distributions as dist
+from numpyro.distributions import Distribution
+
+from prophetverse.effects.base import BaseEffect
+
+
+class Forward(BaseEffect):
+    """Forward effect.
+
+    Forwards a previously fitted effect.
+
+    Parameters
+    ----------
+    prior : Distribution, optional
+        The prior distribution for the constant coefficient, by default None
+        which corresponds to a standard normal distribution.
+    """
+
+    _tags = {
+        "requires_X": False,
+    }
+
+    def __init__(self, effect_name: str) -> None:
+        self.effect_name = effect_name
+        super().__init__()
+
+    def _predict(  # type: ignore[override]
+        self, data: jnp.ndarray, predicted_effects: dict, *args, **kwargs
+    ) -> jnp.ndarray:
+        """Forwards the effect
+
+        Parameters
+        ----------
+        constant_vector : jnp.ndarray
+            A constant vector with the size of the series time indexes
+
+        Returns
+        -------
+        jnp.ndarray
+            The forecasted trend
+        """
+        # Alias for clarity
+
+        return predicted_effects[self.effect_name]
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        return [{"effect_name": "trend"}]

--- a/tests/utils/test_plotting.py
+++ b/tests/utils/test_plotting.py
@@ -2,9 +2,11 @@ from prophetverse.utils.plotting import plot_prior_predictive
 from prophetverse import LinearEffect
 import pandas as pd
 import jax.numpy as jnp
+import pytest
 
 
-def test_plot_prior_predictive():
+@pytest.mark.parametrize("mode", ["time", "x"])
+def test_plot_prior_predictive(mode):
     """Test the plot_prior_predictive function."""
     instance = LinearEffect()
     X = pd.DataFrame(
@@ -16,6 +18,7 @@ def test_plot_prior_predictive():
         X=X,
         y=y,
         predicted_effects={"trend": jnp.array([[2], [4], [6], [8], [10]])},
+        mode=mode,
     )
 
     assert fig is not None


### PR DESCRIPTION
This pull request introduces a new effect module called `Forward` to the `prophetverse` package, allowing users to forward a previously fitted effect. The change includes updates to the package initialization files to expose the new effect, and a new parameterization in the plotting test to support different modes. 

**New effect module:**
* Added the `Forward` effect class in `src/prophetverse/effects/forward.py`, which enables forwarding a previously fitted effect by referencing its name in `predicted_effects`. This is useful for chaining or reusing effects in model pipelines.

**Package initialization updates:**
* Imported and exposed the `Forward` effect in `src/prophetverse/__init__.py` and `src/prophetverse/effects/__init__.py` to make it available as part of the public API. [[1]](diffhunk://#diff-6430b5b275c5446f37823d008805a07c2c45f6b50d2046cda24bac2597333febR24) [[2]](diffhunk://#diff-6430b5b275c5446f37823d008805a07c2c45f6b50d2046cda24bac2597333febR99) [[3]](diffhunk://#diff-6f5a2f89872cc766da98a0a365782101ac5082b597dccfa26cb83dd6917ccaabR21) [[4]](diffhunk://#diff-6f5a2f89872cc766da98a0a365782101ac5082b597dccfa26cb83dd6917ccaabR46)

**Testing improvements:**
* Updated the plotting test in `tests/utils/test_plotting.py` to use `pytest.mark.parametrize`, allowing the test to run for both `"time"` and `"x"` modes, improving coverage and robustness. [[1]](diffhunk://#diff-2ee2ee1fba623edb4f0672ffc692087a136ff69639d6b01ddfb901c6c58b1380R5-R9) [[2]](diffhunk://#diff-2ee2ee1fba623edb4f0672ffc692087a136ff69639d6b01ddfb901c6c58b1380R21)