### PR TITLE
[ENH] ROI likelihood

### DIFF
--- a/src/prophetverse/effects/__init__.py
+++ b/src/prophetverse/effects/__init__.py
@@ -9,6 +9,7 @@ from .fourier import LinearFourierSeasonality
 from .hill import HillEffect
 from .lift_likelihood import LiftExperimentLikelihood
 from .linear import LinearEffect
+from .roi_likelihood import ROILikelihood
 from .log import LogEffect
 from .michaelis_menten import MichaelisMentenEffect
 from .target.multivariate import MultivariateNormal
@@ -35,6 +36,7 @@ __all__ = [
     "MichaelisMentenEffect",
     "ExactLikelihood",
     "LiftExperimentLikelihood",
+    "ROILikelihood",
     "LinearFourierSeasonality",
     "GeometricAdstockEffect",
     "WeibullAdstockEffect",

--- a/src/prophetverse/effects/roi_likelihood.py
+++ b/src/prophetverse/effects/roi_likelihood.py
@@ -1,0 +1,182 @@
+"""ROI (Return on Investment) likelihood effect."""
+
+from typing import Any, Dict
+
+import jax.numpy as jnp
+import numpyro
+import numpyro.distributions as dist
+import pandas as pd
+
+from prophetverse.utils.frame_to_array import series_to_tensor_or_array
+
+from .base import BaseEffect
+
+__all__ = ["ROILikelihood"]
+
+
+class ROILikelihood(BaseEffect):
+    """Apply a normal likelihood to the ROI (Return on Investment) of an effect.
+
+    This effect computes the ROI as the ratio between the sum of the effect's
+    contribution and the sum of the input (captured at transform time). A normal
+    likelihood is applied to this ratio, centered at a given value with a given scale.
+
+    The ROI is computed as:
+        ROI = sum(effect_contribution) / sum(input)
+
+    Parameters
+    ----------
+    effect_name : str
+        The name of the effect to use for computing ROI. This should match
+        the key in predicted_effects dictionary.
+    roi_mean : float
+        The expected (center) value of the ROI. The normal likelihood will be
+        centered at this value.
+    roi_scale : float
+        The scale (standard deviation) of the normal distribution for the ROI.
+        Must be greater than 0.
+
+    Examples
+    --------
+    >>> from prophetverse.effects import ROILikelihood
+    >>> roi_effect = ROILikelihood(
+    ...     effect_name="marketing_spend",
+    ...     roi_mean=2.0,  # Expect $2 return per $1 spent
+    ...     roi_scale=0.5,
+    ... )
+    """
+
+    _tags = {"requires_X": True, "capability:panel": False}
+
+    def __init__(
+        self,
+        effect_name: str,
+        roi_mean: float,
+        roi_scale: float,
+    ):
+        self.effect_name = effect_name
+        self.roi_mean = roi_mean
+        self.roi_scale = roi_scale
+
+        assert self.roi_scale > 0, "roi_scale must be greater than 0"
+
+        super().__init__()
+
+    def _fit(self, y: pd.DataFrame, X: pd.DataFrame, scale: float = 1):
+        """Initialize the effect.
+
+        This method is called during `fit()` of the forecasting model.
+        It receives the Exogenous variables DataFrame and should be used to initialize
+        any necessary parameters or data structures.
+
+        Parameters
+        ----------
+        y : pd.DataFrame
+            The timeseries dataframe
+
+        X : pd.DataFrame
+            The DataFrame to initialize the effect.
+
+        scale : float, optional
+            The scale of the timeseries. For multivariate timeseries, this is
+            a dataframe. For univariate, it is a simple float.
+
+        Returns
+        -------
+        None
+        """
+        self.timeseries_scale = scale
+
+    def _transform(self, X: pd.DataFrame, fh: pd.Index) -> Dict[str, Any]:
+        """Prepare input data to be passed to numpyro model.
+
+        Captures the input values that will be used to compute ROI.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The input DataFrame containing the exogenous variables for the training
+            time indexes, if passed during fit, or for the forecasting time indexes, if
+            passed during predict.
+
+        fh : pd.Index
+            The forecasting horizon as a pandas Index.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Dictionary with the captured input data for ROI computation.
+        """
+        data_dict = {}
+
+        # Capture the input values - sum across all columns if multiple
+        input_array = series_to_tensor_or_array(X)
+        data_dict["input_values"] = input_array
+        data_dict["input_sum"] = jnp.sum(input_array)
+        data_dict["data"] = None
+
+        return data_dict
+
+    def _predict(
+        self, data: Dict, predicted_effects: Dict[str, jnp.ndarray], *args, **kwargs
+    ) -> jnp.ndarray:
+        """Apply and return the effect values.
+
+        Computes the ROI and applies a normal likelihood centered at the expected
+        ROI value.
+
+        Parameters
+        ----------
+        data : Any
+            Data obtained from the transformed method.
+
+        predicted_effects : Dict[str, jnp.ndarray], optional
+            A dictionary containing the predicted effects, by default None.
+
+        Returns
+        -------
+        jnp.ndarray
+            An array with zeros (this effect only adds the likelihood constraint).
+        """
+        input_sum = data["input_sum"]
+
+        # Get the effect contribution
+        effect_contribution = predicted_effects[self.effect_name]
+        effect_sum = jnp.sum(effect_contribution)
+
+        # Compute ROI as the ratio of effect sum to input sum
+        # Add small epsilon to avoid division by zero
+        roi = effect_sum / (input_sum + 1e-10)
+
+        # Apply normal likelihood to the ROI
+        # Use :ignore suffix so that this sample is removed from output dataframe
+        numpyro.sample(
+            "roi_likelihood:ignore",
+            dist.Normal(self.roi_mean, self.roi_scale),
+            obs=roi,
+        )
+
+        # Return zeros - this effect only adds a likelihood constraint
+        return jnp.zeros_like(effect_contribution)
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return.
+
+        Returns
+        -------
+        params : list of dict
+            Parameters to create testing instances of the class.
+        """
+        return [
+            {
+                "effect_name": "trend",
+                "roi_mean": 2.0,
+                "roi_scale": 0.5,
+            }
+        ]

--- a/tests/effects/test_roi_likelihood.py
+++ b/tests/effects/test_roi_likelihood.py
@@ -1,0 +1,99 @@
+import jax.numpy as jnp
+import pandas as pd
+import pytest
+from numpyro import handlers
+
+from prophetverse.effects import ROILikelihood
+
+
+@pytest.fixture
+def X():
+    return pd.DataFrame(
+        data={"spend": [10, 20, 30, 40, 50, 60]},
+        index=pd.date_range("2021-01-01", periods=6),
+    )
+
+
+@pytest.fixture
+def y(X):
+    return pd.DataFrame(index=X.index, data=[1] * len(X))
+
+
+@pytest.fixture
+def roi_likelihood_instance():
+    return ROILikelihood(
+        effect_name="marketing_effect",
+        roi_mean=2.0,
+        roi_scale=0.5,
+    )
+
+
+def test_roi_likelihood_initialization(roi_likelihood_instance):
+    assert roi_likelihood_instance.effect_name == "marketing_effect"
+    assert roi_likelihood_instance.roi_mean == 2.0
+    assert roi_likelihood_instance.roi_scale == 0.5
+
+
+def test_roi_likelihood_scale_must_be_positive():
+    with pytest.raises(AssertionError, match="roi_scale must be greater than 0"):
+        ROILikelihood(effect_name="test", roi_mean=1.0, roi_scale=-0.5)
+
+
+def test_roi_likelihood_fit(X, y, roi_likelihood_instance):
+    roi_likelihood_instance.fit(y=y, X=X, scale=1.5)
+    assert roi_likelihood_instance.timeseries_scale == 1.5
+    assert roi_likelihood_instance._is_fitted
+
+
+def test_roi_likelihood_transform(X, y, roi_likelihood_instance):
+    fh = y.index.get_level_values(-1).unique()
+    roi_likelihood_instance.fit(X=X, y=y)
+    transformed = roi_likelihood_instance.transform(X, fh=fh)
+
+    assert "input_values" in transformed
+    assert "input_sum" in transformed
+    # Sum of [10, 20, 30, 40, 50, 60] = 210
+    assert jnp.isclose(transformed["input_sum"], 210.0)
+
+
+def test_roi_likelihood_predict(X, y, roi_likelihood_instance):
+    fh = X.index.get_level_values(-1).unique()
+
+    # Simulate effect contribution that returns 2x the input (ROI = 2.0)
+    # Input sum = 210, so effect sum should be 420 for ROI = 2.0
+    effect_contribution = jnp.array([20, 40, 60, 80, 100, 120]).reshape((-1, 1))
+
+    roi_likelihood_instance.fit(X=X, y=y)
+    data = roi_likelihood_instance.transform(X=X, fh=fh)
+
+    exec_trace = handlers.trace(roi_likelihood_instance.predict).get_trace(
+        data=data, predicted_effects={"marketing_effect": effect_contribution}
+    )
+
+    # Check that the likelihood sample was created
+    assert "roi_likelihood:ignore" in exec_trace
+
+    trace_likelihood = exec_trace["roi_likelihood:ignore"]
+    assert trace_likelihood["type"] == "sample"
+    assert trace_likelihood["is_observed"]
+
+    # Check that the observed ROI is correct (420 / 210 = 2.0)
+    observed_roi = trace_likelihood["value"]
+    assert jnp.isclose(observed_roi, 2.0)
+
+
+def test_roi_likelihood_returns_zeros(X, y, roi_likelihood_instance):
+    fh = X.index.get_level_values(-1).unique()
+
+    effect_contribution = jnp.array([20, 40, 60, 80, 100, 120]).reshape((-1, 1))
+
+    roi_likelihood_instance.fit(X=X, y=y)
+    data = roi_likelihood_instance.transform(X=X, fh=fh)
+
+    result = roi_likelihood_instance.predict(
+        data=data, predicted_effects={"marketing_effect": effect_contribution}
+    )
+
+    # Should return zeros with same shape as effect_contribution
+    assert result.shape == effect_contribution.shape
+    assert jnp.all(result == 0)


### PR DESCRIPTION
This pull request introduces a new effect, `ROILikelihood`, to the `prophetverse.effects` module. The `ROILikelihood` effect allows users to apply a normal likelihood constraint to the return on investment (ROI) of another effect, which is useful for enforcing prior knowledge or business constraints in probabilistic modeling. The pull request also adds comprehensive unit tests for this new effect and updates the module's exports.

**Key changes:**

**New ROI Likelihood Effect:**
- Added the `ROILikelihood` class in `src/prophetverse/effects/roi_likelihood.py`, which computes the ROI as the ratio of the sum of an effect's contribution to the sum of its input and applies a normal likelihood centered at a user-specified mean and scale. Includes parameter validation, fitting, transformation, prediction, and test parameter support.

**Module Integration:**
- Registered `ROILikelihood` in the `prophetverse.effects` package by importing it in `src/prophetverse/effects/__init__.py` and adding it to the `__all__` list for public API exposure. [[1]](diffhunk://#diff-6f5a2f89872cc766da98a0a365782101ac5082b597dccfa26cb83dd6917ccaabR12) [[2]](diffhunk://#diff-6f5a2f89872cc766da98a0a365782101ac5082b597dccfa26cb83dd6917ccaabR39)

**Testing:**
- Added a new test file `tests/effects/test_roi_likelihood.py` with fixtures and tests covering initialization, parameter validation, fitting, transformation, prediction, and output shape/values for `ROILikelihood`.