### PR TITLE
[BUG] Propagate capability:panel and feature:panel_hyperpriors tags in ChainedEffects

### DIFF
--- a/src/prophetverse/effects/chain.py
+++ b/src/prophetverse/effects/chain.py
@@ -42,7 +42,23 @@ class ChainedEffects(BaseMetaEstimatorMixin, BaseEffect):
                     f"Invalid type {type(val)} for step {i}. Must be a tuple or BaseEffect."
                 )
 
-        self.set_tags(**{"requires_X": steps[0][1].get_tag("requires_X", False)})
+        # Propagate tags from inner effects
+        all_panel = all(
+            effect.get_tag("capability:panel", False)
+            for _, effect in self.named_steps
+        )
+        any_hyperpriors = any(
+            effect.get_tag("feature:panel_hyperpriors", False)
+            for _, effect in self.named_steps
+        )
+
+        self.set_tags(
+            **{
+                "requires_X": steps[0][1].get_tag("requires_X", False),
+                "capability:panel": all_panel,
+                "feature:panel_hyperpriors": any_hyperpriors,
+            }
+        )
 
     def _fit(self, y: Any, X: Any, scale: float = 1.0):
         """


### PR DESCRIPTION
Now ChainedEffects.__init__ propagates:
- capability:panel = True when ALL inner effects are panel-capable
- feature:panel_hyperpriors = True when ANY inner effect has hyperpriors
- This ensures panel data flows through to inner effects, preserving their hierarchical parametrisation (shared loc + scale across series).


Fix #337 