### PR TITLE
[ENH] Add optional start_period and end_period to LinearFourierSeasonality (#234)

### DIFF
--- a/src/prophetverse/effects/fourier.py
+++ b/src/prophetverse/effects/fourier.py
@@ -49,6 +49,8 @@ def _coerce_period(value, index: pd.Index):
     # DatetimeIndex (or anything else – fall back to Timestamp)
     if isinstance(value, pd.Timestamp):
         return value
+    if isinstance(value, pd.Period):
+        return value.to_timestamp()
     return pd.Timestamp(value)
 
 
@@ -198,6 +200,12 @@ class LinearFourierSeasonality(BaseEffect):
         start = _coerce_period(self.start_period, time_index)
         end = _coerce_period(self.end_period, time_index)
 
+        if start is not None and end is not None and start > end:
+            raise ValueError(
+                f"start_period ({self.start_period!r}) must be earlier than or "
+                f"equal to end_period ({self.end_period!r})."
+            )
+
         mask = np.ones(len(time_index), dtype=np.float32)
         if start is not None:
             mask *= (time_index >= start).astype(np.float32)
@@ -206,7 +214,7 @@ class LinearFourierSeasonality(BaseEffect):
 
         return jnp.array(mask)
 
-    def _transform(self, X: pd.DataFrame, fh: pd.Index) -> jnp.ndarray:
+    def _transform(self, X: pd.DataFrame, fh: pd.Index) -> dict:
         """Prepare input data to be passed to numpyro model.
 
         This method return a jnp.ndarray of sines and cosines of the given

--- a/tests/effects/test_fourier.py
+++ b/tests/effects/test_fourier.py
@@ -257,6 +257,19 @@ def test_full_range_mask_equivalent_to_no_mask(  exog_data_10days):
     assert jnp.allclose(data_windowed["mask"], 1.0)
 
 
+def test_start_after_end_raises(exog_data_10days):
+    """start_period > end_period should raise ValueError, not silently zero mask."""
+    effect = LinearFourierSeasonality(
+        sp_list=[7], fourier_terms_list=[1], freq="D",
+        start_period="2021-01-08",
+        end_period="2021-01-04",
+    )
+    fh = exog_data_10days.index
+    effect.fit(X=exog_data_10days, y=None)
+    with pytest.raises(ValueError, match="start_period.*end_period"):
+        effect.transform(X=exog_data_10days, fh=fh)
+
+
 def test_predict_panel_mask_reshape(exog_data_10days):
     effect = LinearFourierSeasonality(
         sp_list=[7], fourier_terms_list=[1], freq="D",
@@ -313,4 +326,12 @@ def test_coerce_period_timestamp_passthrough():
     ts = pd.Timestamp("2021-01-05")
     result = _coerce_period(ts, idx)
     assert result == ts
+
+
+def test_coerce_period_period_with_datetime_index():
+    idx = pd.date_range("2021-01-01", periods=10, freq="D")
+    val = pd.Period("2021-01-05", freq="D")
+    result = _coerce_period(val, idx)
+    assert isinstance(result, pd.Timestamp)
+    assert result == pd.Timestamp("2021-01-05")
 


### PR DESCRIPTION
Description
This PR implements the enhancement requested in #234, adding optional time-window restrictions to LinearFourierSeasonality. It is related to the parent issue #214, which highlighted the gap between FBProphet's seasonality flexibility and what prophetverse currently offers.

What Changed
Two new optional parameters are added to LinearFourierSeasonality:

"start_period" - the component is forced to zero for all time steps before this date/period
"end_period" - the component is forced to zero for all time steps after this date/period
Both default to None, preserving full backward compatibility. When neither is set, the behaviour is identical to before — no mask is built, no overhead.

Implementation Notes
The masking is applied as a multiplicative gate on the output of the effect, not on the Fourier features themselves. The Fourier coefficients are still sampled from their priors across the full dataset, providing proper regularization. Only the contribution to the forecast is zeroed outside the window. This is the correct Bayesian interpretation: the coefficients exist globally, but their effect on the observed signal is restricted.

The mask is built in "_transform" (data preparation phase) and applied in "_predict" (model execution phase), consistent with the existing lifecycle pattern of all effects in this codebase.


