### PR TITLE
fix: Resolve broken contributing guidelines link and add local setup file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Prophetverse
+
+First off, thank you for considering contributing to Prophetverse! It's people like you that make Prophetverse such a great tool.
+
+If you are new to open source, we highly recommend checking out [Open Source Guides](https://opensource.guide/) to learn how to open issues, create pull requests, and more.
+
+## Local Environment Setup
+
+To contribute to the codebase, you will need to set up your local development environment. Prophetverse uses [Poetry](https://python-poetry.org/) for dependency management and [pre-commit](https://pre-commit.com/) to ensure code quality.
+
+### Prerequisites
+
+- Python 3.10 or newer (up to <3.14)
+- [Poetry](https://python-poetry.org/docs/#installation)
+- Git
+
+### Installation Steps
+
+1. **Clone the repository:**
+   ```bash
+   git clone https://github.com/felipeangelimvieira/prophetverse.git
+   cd prophetverse
+   ```
+
+2. **Install dependencies:**
+   Prophetverse uses `poetry` to manage dependencies. To install the project along with its development dependencies, run:
+   ```bash
+   poetry install --extras "dev"
+   ```
+
+3. **Install pre-commit hooks:**
+   We use `pre-commit` to catch format issues, typing errors, and enforce coding standards. To install the hooks, run:
+   ```bash
+   poetry run pre-commit install
+   ```
+   *Note: We use `commitlint` (which requires Node/npm) among other hooks to enforce Conventional Commits. Ensure your commit messages follow this convention.*
+
+4. **Running Tests:**
+   You can run tests using `pytest` to ensure everything is working correctly:
+   ```bash
+   poetry run pytest
+   ```
+
+## Development Guidelines
+
+- **Code Quality:** We use `black`, `isort`, `flake8`, and `mypy` for formatting, linting, and type checking. These are automatically verified via pre-commit hooks when you attempt to commit your code.
+- **Commit Messages:** We follow Conventional Commits. Commits must be properly formatted (e.g., `feat: Add new feature`, `fix: Resolve issue #123`).
+
+We look forward to your contributions!

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Prophetverse is similar to the original Prophet model in many aspects, but it ha
 
 ## 🤝 Contributing to Prophetverse
 
-We welcome contributions! Check out our [contributing guidelines](https://prophetverse.com/development/development-guide//) to get started.
+We welcome contributions! Check out our [contributing guidelines](CONTRIBUTING.md) to get started.
 
 ## 📚 Documentation
 


### PR DESCRIPTION
Fixes #343

## Description
This PR addresses the issue regarding the broken contributing guidelines link (`404 error`) in the `README.md` file.

Changes made:
- Added a new `CONTRIBUTING.md` file in the root directory.
-  Included a reference to [opensource.guide](https://opensource.guide/) for new open-source contributors.
- Detailed the local environment setup instructions inside `CONTRIBUTING.md`, including steps for `poetry` dependencies and `pre-commit` hooks.
- Updated the link in `README.md` to point to the new `CONTRIBUTING.md` file using a relative path.
