### PR TITLE
[BUG] store resolved rng_key as public attribute in BaseInferenceEngine

### DIFF
--- a/src/prophetverse/engine/base.py
+++ b/src/prophetverse/engine/base.py
@@ -16,7 +16,7 @@ class BaseInferenceEngine(BaseObject):
     model : Callable
         The model to be used for inference.
     rng_key : Optional[jax.random.PRNGKey]
-        The random number generator key. If not provided, a default key with value 42
+        The random number generator key. If not provided, a default key with value 0
         will be used.
 
     Attributes
@@ -33,7 +33,7 @@ class BaseInferenceEngine(BaseObject):
 
     def __init__(self, rng_key=None):
         if rng_key is None:
-            rng_key = jax.random.PRNGKey(42)
+            rng_key = jax.random.PRNGKey(0)
         self.rng_key = rng_key
         self._rng_key = rng_key
 

--- a/src/prophetverse/engine/base.py
+++ b/src/prophetverse/engine/base.py
@@ -16,7 +16,7 @@ class BaseInferenceEngine(BaseObject):
     model : Callable
         The model to be used for inference.
     rng_key : Optional[jax.random.PRNGKey]
-        The random number generator key. If not provided, a default key with value 0
+        The random number generator key. If not provided, a default key with value 42
         will be used.
 
     Attributes
@@ -32,10 +32,9 @@ class BaseInferenceEngine(BaseObject):
     }
 
     def __init__(self, rng_key=None):
-        self.rng_key = rng_key
-
         if rng_key is None:
-            rng_key = jax.random.PRNGKey(0)
+            rng_key = jax.random.PRNGKey(42)
+        self.rng_key = rng_key
         self._rng_key = rng_key
 
     # pragma: no cover


### PR DESCRIPTION
Closes #357

## What changed

In `BaseInferenceEngine.__init__`, resolve `rng_key` before assigning to the public attribute.

## Why

When `rng_key=None` was stored as the public attribute, `get_params()` returned `None`. skbase clones the estimator internally during `fit()`, reconstructing the engine from `get_params()` — which re-called `__init__(rng_key=None)` and created a new `PRNGKey` at an unpredictable point in JAX's lifecycle. This caused non-determinism across kernel restarts, and in some cases complete optimizer divergence.

## Fix

```python
# Before
def __init__(self, rng_key=None):
    self.rng_key = rng_key        # stored None — lost on skbase clone
    if rng_key is None:
        rng_key = jax.random.PRNGKey(0)
    self._rng_key = rng_key

# After
def __init__(self, rng_key=None):
    if rng_key is None:
        rng_key = jax.random.PRNGKey(42)
    self.rng_key = rng_key        # stores resolved key — survives clone
    self._rng_key = rng_key
